### PR TITLE
fix(restart): loud save-failure UX + 3-layer JSONL resolution (thrum-ufv5.7)

### DIFF
--- a/cmd/thrum/hints_integration_test.go
+++ b/cmd/thrum/hints_integration_test.go
@@ -210,6 +210,43 @@ func runInDir(t *testing.T, dir, name string, args ...string) error {
 	return c.Run()
 }
 
+// writeSnapshotTestIdentity writes a minimal identity file that the
+// snapshot save command can load without ambiguity. Load-bearing fields:
+//   - agent.name: used to select the identity file by THRUM_NAME
+//   - worktree: used by the mtime fallback to derive the project-dir slug
+//   - agent_pid: used by restart.FindSessionJSONL; pass 0 to force the
+//     no-pid path with agent.list also returning no-match, or a high
+//     guaranteed-dead PID (99999999) to force the no-jsonl path.
+//   - runtime: must equal "claude" since snapshot save today only works
+//     for the Claude runtime.
+//
+// repoDir is the agent's worktree root (where .thrum/identities/ is
+// written). Name is the agent name the subprocess will resolve via
+// THRUM_NAME. The identity file lands at
+// <repoDir>/.thrum/identities/<name>.json.
+func writeSnapshotTestIdentity(t *testing.T, repoDir, name string, pid int) {
+	t.Helper()
+	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
+	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir identities: %v", err)
+	}
+	identity := map[string]any{
+		"version":   5,
+		"repo_id":   "test-repo",
+		"agent":     map[string]any{"name": name, "role": "impl", "module": "testmod"},
+		"worktree":  repoDir,
+		"agent_pid": pid,
+		"runtime":   "claude",
+	}
+	b, err := json.MarshalIndent(identity, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(identitiesDir, name+".json"), b, 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+}
+
 // TestIntegration_SnapshotSaveNoJSONL_TextMode verifies the
 // snapshot.save.no-jsonl hint lands on stderr when `thrum tmux snapshot save`
 // cannot resolve a Claude JSONL for the recorded agent PID.
@@ -228,29 +265,7 @@ func TestIntegration_SnapshotSaveNoJSONL_TextMode(t *testing.T) {
 
 	repoDir := t.TempDir()
 	fakeHome := t.TempDir()
-
-	// Write a minimal identity file. Must live under .thrum/identities/<name>.json
-	// and include agent.name so LoadIdentityWithPath can resolve a single
-	// identity without ambiguity.
-	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
-	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
-		t.Fatalf("mkdir identities: %v", err)
-	}
-	identity := map[string]any{
-		"version":   5,
-		"repo_id":   "test-repo",
-		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
-		"worktree":  repoDir,
-		"agent_pid": 99999999,
-		"runtime":   "claude",
-	}
-	idBytes, err := json.MarshalIndent(identity, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal identity: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
-		t.Fatalf("write identity: %v", err)
-	}
+	writeSnapshotTestIdentity(t, repoDir, "testagent", 99999999)
 
 	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save")
 	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
@@ -289,23 +304,7 @@ func TestIntegration_SnapshotSaveNoJSONL_ThrumNoHintsSuppresses(t *testing.T) {
 
 	repoDir := t.TempDir()
 	fakeHome := t.TempDir()
-
-	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
-	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
-		t.Fatalf("mkdir identities: %v", err)
-	}
-	identity := map[string]any{
-		"version":   5,
-		"repo_id":   "test-repo",
-		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
-		"worktree":  repoDir,
-		"agent_pid": 99999999,
-		"runtime":   "claude",
-	}
-	idBytes, _ := json.MarshalIndent(identity, "", "  ")
-	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
-		t.Fatalf("write identity: %v", err)
-	}
+	writeSnapshotTestIdentity(t, repoDir, "testagent", 99999999)
 
 	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save")
 	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME", "THRUM_NO_HINTS"),
@@ -358,24 +357,8 @@ func TestIntegration_SnapshotSaveMtimeFallback_UsesProjectDir(t *testing.T) {
 
 	repoDir := t.TempDir()
 	fakeHome := t.TempDir()
-
-	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
-	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
-		t.Fatalf("mkdir identities: %v", err)
-	}
 	// agent_pid deliberately unresolvable — forces the fallback path.
-	identity := map[string]any{
-		"version":   5,
-		"repo_id":   "test-repo",
-		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
-		"worktree":  repoDir,
-		"agent_pid": 99999999,
-		"runtime":   "claude",
-	}
-	idBytes, _ := json.MarshalIndent(identity, "", "  ")
-	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
-		t.Fatalf("write identity: %v", err)
-	}
+	writeSnapshotTestIdentity(t, repoDir, "testagent", 99999999)
 
 	// Mirror encodeCwd from internal/restart: strip leading '/', replace
 	// '/' and '.' with '-', prepend '-'. repoDir from t.TempDir() has no
@@ -443,25 +426,9 @@ func TestIntegration_SnapshotSaveExplicitJSONL_BypassesAutoDetect(t *testing.T) 
 
 	repoDir := t.TempDir()
 	fakeHome := t.TempDir()
-
-	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
-	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
-		t.Fatalf("mkdir identities: %v", err)
-	}
 	// PID stays unresolvable — proving the flag bypasses auto-detect, not
 	// that auto-detect happened to work.
-	identity := map[string]any{
-		"version":   5,
-		"repo_id":   "test-repo",
-		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
-		"worktree":  repoDir,
-		"agent_pid": 99999999,
-		"runtime":   "claude",
-	}
-	idBytes, _ := json.MarshalIndent(identity, "", "  ")
-	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
-		t.Fatalf("write identity: %v", err)
-	}
+	writeSnapshotTestIdentity(t, repoDir, "testagent", 99999999)
 
 	// Craft a minimal JSONL. ExtractConversation filters to user+assistant
 	// message rows with text content; we supply one user row.
@@ -497,3 +464,190 @@ func TestIntegration_SnapshotSaveExplicitJSONL_BypassesAutoDetect(t *testing.T) 
 	}
 }
 
+
+// TestIntegration_SnapshotSaveNoPID_TextMode verifies the snapshot.save.no-pid
+// hint wires end-to-end when the identity file has agent_pid=0 AND the daemon
+// lookup returns no-match. The daemon lookup branch in saveCmd gracefully
+// tolerates a dial failure (if err != nil { ... }), so the test simply
+// leaves no daemon running — the loop over `agents` finds nothing and the
+// pid==0 refusal fires with the hint attached.
+func TestIntegration_SnapshotSaveNoPID_TextMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+	// agent_pid=0 triggers the fallback path; with no daemon the lookup
+	// returns empty and the pid==0 error returns with the no-pid hint.
+	writeSnapshotTestIdentity(t, repoDir, "testagent", 0)
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save")
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+	)
+	_, errBuf := captureOut(cmd)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-zero exit when no PID is resolvable")
+	}
+
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "[snapshot.save.no-pid]") {
+		t.Errorf("stderr missing hint code [snapshot.save.no-pid], got:\n%s", stderr)
+	}
+	// Remediation must reference the specific agent name so the re-register
+	// command is copy/paste-ready.
+	if !strings.Contains(stderr, "testagent") {
+		t.Errorf("stderr should name the agent in the remediation command; got:\n%s", stderr)
+	}
+}
+
+// TestIntegration_SnapshotSaveExtractFailed_TextMode verifies the
+// snapshot.save.extract-failed hint fires when the supplied JSONL is
+// present (passes os.Stat pre-flight) but ExtractConversation's
+// os.Open returns an error.
+//
+// Note on trigger choice: ExtractConversation uses bufio.Scanner with a
+// "skip unmarshal errors" policy, so feeding corrupt content would just
+// produce an empty snapshot without error. The reliable portable trigger
+// for an Open error when Stat succeeds is a chmod-000 file — Stat reads
+// the dir entry (no read perm on file needed), Open fails EACCES.
+// Skipped on Windows (chmod semantics differ).
+func TestIntegration_SnapshotSaveExtractFailed_TextMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-000 is bypassed by root; test requires non-root uid")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+	writeSnapshotTestIdentity(t, repoDir, "testagent", 99999999)
+
+	unreadablePath := filepath.Join(t.TempDir(), "unreadable.jsonl")
+	if err := os.WriteFile(unreadablePath, []byte(`{"type":"user"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	if err := os.Chmod(unreadablePath, 0o000); err != nil {
+		t.Fatalf("chmod 000: %v", err)
+	}
+	// Restore perms after test so t.TempDir cleanup can delete the file.
+	t.Cleanup(func() { _ = os.Chmod(unreadablePath, 0o600) })
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save", "--jsonl", unreadablePath)
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+	)
+	_, errBuf := captureOut(cmd)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-zero exit when JSONL can't be opened")
+	}
+
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "[snapshot.save.extract-failed]") {
+		t.Errorf("stderr missing hint code [snapshot.save.extract-failed], got:\n%s", stderr)
+	}
+	// The hint should name the path for copy/paste remediation (inspect/ls).
+	if !strings.Contains(stderr, unreadablePath) {
+		t.Errorf("stderr should reference the JSONL path, got:\n%s", stderr)
+	}
+}
+
+// TestIntegration_SnapshotSaveJSONLNotFound_TextMode verifies the pre-flight
+// os.Stat on --jsonl detects typo'd paths and fires the distinct
+// snapshot.save.jsonl-not-found hint — distinguishing "path doesn't exist"
+// from "path exists but can't be read/parsed" (the extract-failed case).
+func TestIntegration_SnapshotSaveJSONLNotFound_TextMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+	writeSnapshotTestIdentity(t, repoDir, "testagent", 99999999)
+
+	bogusPath := filepath.Join(t.TempDir(), "does-not-exist.jsonl")
+	// Explicitly do NOT create bogusPath — os.Stat must report ENOENT.
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save", "--jsonl", bogusPath)
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+	)
+	_, errBuf := captureOut(cmd)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-zero exit when --jsonl path is missing")
+	}
+
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "[snapshot.save.jsonl-not-found]") {
+		t.Errorf("stderr missing hint code [snapshot.save.jsonl-not-found], got:\n%s", stderr)
+	}
+	// Crucial: the extract-failed hint must NOT also fire — that would
+	// re-introduce the confusion the new code exists to avoid.
+	if strings.Contains(stderr, "[snapshot.save.extract-failed]") {
+		t.Errorf("jsonl-not-found path must not ALSO emit extract-failed hint; stderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, bogusPath) {
+		t.Errorf("stderr should echo the bad path for copy/paste fix; got:\n%s", stderr)
+	}
+}
+
+// TestIntegration_SnapshotSaveNoJSONL_WorktreeMissing_TextMode verifies the
+// WorktreeMissing context variant: when the identity file lacks a worktree
+// field, the mtime fallback can't run. The hint must render the
+// "missing the 'worktree' field" message so operators know where to look
+// instead of hunting for sessions/<pid>.json or project dirs.
+func TestIntegration_SnapshotSaveNoJSONL_WorktreeMissing_TextMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+
+	// Hand-craft an identity that deliberately omits 'worktree' to trigger
+	// the WorktreeMissing branch. writeSnapshotTestIdentity always populates
+	// worktree, so this test bypasses the helper.
+	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
+	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir identities: %v", err)
+	}
+	identity := map[string]any{
+		"version":   5,
+		"repo_id":   "test-repo",
+		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
+		"agent_pid": 99999999,
+		"runtime":   "claude",
+		// worktree field intentionally OMITTED
+	}
+	b, _ := json.MarshalIndent(identity, "", "  ")
+	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), b, 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save")
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+	)
+	_, errBuf := captureOut(cmd)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-zero exit when worktree is missing and auto-detect fails")
+	}
+
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "[snapshot.save.no-jsonl]") {
+		t.Errorf("stderr missing hint code [snapshot.save.no-jsonl], got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "missing the 'worktree' field") {
+		t.Errorf("stderr should explain worktree field is missing (context-specific message); got:\n%s", stderr)
+	}
+}

--- a/cmd/thrum/hints_integration_test.go
+++ b/cmd/thrum/hints_integration_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // L4 integration test coverage for the 8-code pilot catalog.
@@ -206,5 +208,292 @@ func runInDir(t *testing.T, dir, name string, args ...string) error {
 	c.Stdout = nil
 	c.Stderr = nil
 	return c.Run()
+}
+
+// TestIntegration_SnapshotSaveNoJSONL_TextMode verifies the
+// snapshot.save.no-jsonl hint lands on stderr when `thrum tmux snapshot save`
+// cannot resolve a Claude JSONL for the recorded agent PID.
+//
+// Fixture: minimal .thrum/identities/<name>.json with agent_pid pointed at a
+// PID that does not have a matching ~/.claude/sessions/<pid>.json (we use a
+// fresh HOME tmpdir so the file cannot exist regardless of host state).
+// The PID value itself is arbitrary — 99999999 is chosen to be outside
+// normal PID ranges to reduce flake on systems that assigned it to a real
+// process. Either way the sessions/<pid>.json lookup fails in the fresh HOME.
+func TestIntegration_SnapshotSaveNoJSONL_TextMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+
+	// Write a minimal identity file. Must live under .thrum/identities/<name>.json
+	// and include agent.name so LoadIdentityWithPath can resolve a single
+	// identity without ambiguity.
+	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
+	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir identities: %v", err)
+	}
+	identity := map[string]any{
+		"version":   5,
+		"repo_id":   "test-repo",
+		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
+		"worktree":  repoDir,
+		"agent_pid": 99999999,
+		"runtime":   "claude",
+	}
+	idBytes, err := json.MarshalIndent(identity, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save")
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+	)
+	_, errBuf := captureOut(cmd)
+	runErr := cmd.Run()
+	if runErr == nil {
+		t.Fatal("expected non-zero exit when no JSONL is resolvable")
+	}
+
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "[snapshot.save.no-jsonl]") {
+		t.Errorf("stderr missing hint code [snapshot.save.no-jsonl], got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "warn") {
+		t.Errorf("stderr missing 'warn' severity label, got:\n%s", stderr)
+	}
+	// Remediation must include a copy/paste-ready ls command so the operator
+	// can verify which of (a) sessions/<pid>.json, (b) projects/ dir is missing.
+	if !strings.Contains(stderr, "99999999.json") {
+		t.Errorf("stderr should reference sessions/<pid>.json path, got:\n%s", stderr)
+	}
+}
+
+// TestIntegration_SnapshotSaveNoJSONL_ThrumNoHintsSuppresses verifies the env
+// kill-switch suppresses the hint trailer even when the failure condition
+// fires. The underlying error still returns non-zero — suppression is for
+// the hint text only.
+func TestIntegration_SnapshotSaveNoJSONL_ThrumNoHintsSuppresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+
+	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
+	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir identities: %v", err)
+	}
+	identity := map[string]any{
+		"version":   5,
+		"repo_id":   "test-repo",
+		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
+		"worktree":  repoDir,
+		"agent_pid": 99999999,
+		"runtime":   "claude",
+	}
+	idBytes, _ := json.MarshalIndent(identity, "", "  ")
+	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save")
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME", "THRUM_NO_HINTS"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+		"THRUM_NO_HINTS=1",
+	)
+	_, errBuf := captureOut(cmd)
+	_ = cmd.Run()
+
+	stderr := errBuf.String()
+	if strings.Contains(stderr, "[snapshot.save.no-jsonl]") {
+		t.Errorf("THRUM_NO_HINTS=1 must suppress hint code, got stderr:\n%s", stderr)
+	}
+}
+
+// filterEnvVars returns env minus any entries whose key matches one of remove.
+// Used to drop inherited test-parent THRUM_HOME / HOME etc. so the subprocess
+// sees only the explicit overrides set by the test.
+func filterEnvVars(env []string, remove ...string) []string {
+	skip := make(map[string]bool, len(remove))
+	for _, k := range remove {
+		skip[k] = true
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			out = append(out, kv)
+			continue
+		}
+		if skip[key] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// TestIntegration_SnapshotSaveMtimeFallback_UsesProjectDir verifies the
+// layer-2 fallback kicks in when PID-based lookup fails (no sessions/<pid>.json)
+// but the per-worktree project directory holds at least one .jsonl. The save
+// should complete successfully using the newest-mtime JSONL — no hint emits,
+// and the extracted conversation lands in the snapshot.
+func TestIntegration_SnapshotSaveMtimeFallback_UsesProjectDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+
+	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
+	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir identities: %v", err)
+	}
+	// agent_pid deliberately unresolvable — forces the fallback path.
+	identity := map[string]any{
+		"version":   5,
+		"repo_id":   "test-repo",
+		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
+		"worktree":  repoDir,
+		"agent_pid": 99999999,
+		"runtime":   "claude",
+	}
+	idBytes, _ := json.MarshalIndent(identity, "", "  ")
+	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+
+	// Mirror encodeCwd from internal/restart: strip leading '/', replace
+	// '/' and '.' with '-', prepend '-'. repoDir from t.TempDir() has no
+	// dots so we only need the slash substitution.
+	slug := "-" + strings.ReplaceAll(strings.TrimPrefix(repoDir, "/"), "/", "-")
+	slug = strings.ReplaceAll(slug, ".", "-")
+	projectDir := filepath.Join(fakeHome, ".claude", "projects", slug)
+	if err := os.MkdirAll(projectDir, 0o750); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	// Write two JSONL files with different mtimes; save must pick the newer.
+	olderPath := filepath.Join(projectDir, "older.jsonl")
+	newerPath := filepath.Join(projectDir, "newer.jsonl")
+	olderLine := `{"type":"user","isSidechain":false,"message":{"role":"user","content":[{"type":"text","text":"OLDER content"}]}}` + "\n"
+	newerLine := `{"type":"user","isSidechain":false,"message":{"role":"user","content":[{"type":"text","text":"NEWER content"}]}}` + "\n"
+	if err := os.WriteFile(olderPath, []byte(olderLine), 0o600); err != nil {
+		t.Fatalf("write older: %v", err)
+	}
+	if err := os.WriteFile(newerPath, []byte(newerLine), 0o600); err != nil {
+		t.Fatalf("write newer: %v", err)
+	}
+	// Force older to actually be older in case of 1s filesystem resolution.
+	past := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(olderPath, past, past); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save")
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+	)
+	outBuf, errBuf := captureOut(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("expected success via mtime fallback; err=%v\nstdout:%s\nstderr:%s", err, outBuf.String(), errBuf.String())
+	}
+
+	snapshotPath := filepath.Join(repoDir, ".thrum", "restart", "testagent.md")
+	data, err := os.ReadFile(snapshotPath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("snapshot not written: %v", err)
+	}
+	if !strings.Contains(string(data), "NEWER content") {
+		t.Errorf("snapshot should contain newer JSONL content; got:\n%s", string(data))
+	}
+	if strings.Contains(string(data), "OLDER content") {
+		t.Errorf("snapshot should NOT contain older JSONL content (mtime picked wrong file); got:\n%s", string(data))
+	}
+	if strings.Contains(errBuf.String(), "[snapshot.save.no-jsonl]") {
+		t.Errorf("fallback success path must not emit no-jsonl hint; stderr:\n%s", errBuf.String())
+	}
+}
+
+// TestIntegration_SnapshotSaveExplicitJSONL_BypassesAutoDetect verifies that
+// `--jsonl <path>` short-circuits both PID-based lookup and the mtime
+// fallback — letting the caller directly supply the conversation file even
+// when auto-detect can't find it. The file must still be a real readable
+// file (ExtractConversation will fail otherwise), so we write a minimal
+// JSONL with a single user message that extracts to a non-empty snapshot.
+func TestIntegration_SnapshotSaveExplicitJSONL_BypassesAutoDetect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in -short")
+	}
+	bin := buildTestBinary(t)
+
+	repoDir := t.TempDir()
+	fakeHome := t.TempDir()
+
+	identitiesDir := filepath.Join(repoDir, ".thrum", "identities")
+	if err := os.MkdirAll(identitiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir identities: %v", err)
+	}
+	// PID stays unresolvable — proving the flag bypasses auto-detect, not
+	// that auto-detect happened to work.
+	identity := map[string]any{
+		"version":   5,
+		"repo_id":   "test-repo",
+		"agent":     map[string]any{"name": "testagent", "role": "impl", "module": "testmod"},
+		"worktree":  repoDir,
+		"agent_pid": 99999999,
+		"runtime":   "claude",
+	}
+	idBytes, _ := json.MarshalIndent(identity, "", "  ")
+	if err := os.WriteFile(filepath.Join(identitiesDir, "testagent.json"), idBytes, 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+
+	// Craft a minimal JSONL. ExtractConversation filters to user+assistant
+	// message rows with text content; we supply one user row.
+	jsonlPath := filepath.Join(t.TempDir(), "override-session.jsonl")
+	line := `{"type":"user","isSidechain":false,"message":{"role":"user","content":[{"type":"text","text":"hello from explicit JSONL"}]}}` + "\n"
+	if err := os.WriteFile(jsonlPath, []byte(line), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	cmd := exec.Command(bin, "--repo", repoDir, "tmux", "snapshot", "save", "--jsonl", jsonlPath)
+	cmd.Env = append(filterEnvVars(os.Environ(), "THRUM_HOME", "HOME", "THRUM_NAME"),
+		"HOME="+fakeHome,
+		"THRUM_NAME=testagent",
+	)
+	outBuf, errBuf := captureOut(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("expected success with --jsonl override; err=%v\nstdout:%s\nstderr:%s", err, outBuf.String(), errBuf.String())
+	}
+
+	// Success path prints the saved-line count; snapshot should land under
+	// repoDir/.thrum/restart/testagent.md.
+	snapshotPath := filepath.Join(repoDir, ".thrum", "restart", "testagent.md")
+	data, err := os.ReadFile(snapshotPath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("snapshot file not written at %s: %v", snapshotPath, err)
+	}
+	if !strings.Contains(string(data), "hello from explicit JSONL") {
+		t.Errorf("snapshot missing extracted content; got:\n%s", string(data))
+	}
+	// Stderr must NOT carry the no-jsonl hint when the override succeeded.
+	if strings.Contains(errBuf.String(), "[snapshot.save.no-jsonl]") {
+		t.Errorf("--jsonl success path must not emit no-jsonl hint; stderr:\n%s", errBuf.String())
+	}
 }
 

--- a/cmd/thrum/main.go
+++ b/cmd/thrum/main.go
@@ -7943,24 +7943,26 @@ func restartSnapshotSubcmds() []*cobra.Command {
 
 			pid := idFile.AgentPID
 			if pid == 0 {
-				// Fallback: query daemon for the agent's AgentPID
-				client, err := getClient()
-				if err != nil {
-					return fmt.Errorf("connect to daemon: %w", err)
-				}
-				defer func() { _ = client.Close() }()
-
-				var agents []struct {
-					AgentID  string `json:"agent_id"`
-					AgentPID int    `json:"agent_pid"`
-				}
-				if err := client.Call("agent.list", nil, &agents); err == nil {
-					for _, a := range agents {
-						if a.AgentID == agentName && a.AgentPID > 0 {
-							pid = a.AgentPID
-							break
+				// Fallback: query the daemon for the agent's AgentPID. The
+				// daemon path is itself a best-effort fallback — if we
+				// can't reach the daemon (dial failure, closed socket) we
+				// fall through to the pid==0 refusal below rather than
+				// returning an unrelated "connect to daemon" error. The
+				// no-pid hint then renders with actionable remediation.
+				if client, err := getClient(); err == nil {
+					var agents []struct {
+						AgentID  string `json:"agent_id"`
+						AgentPID int    `json:"agent_pid"`
+					}
+					if err := client.Call("agent.list", nil, &agents); err == nil {
+						for _, a := range agents {
+							if a.AgentID == agentName && a.AgentPID > 0 {
+								pid = a.AgentPID
+								break
+							}
 						}
 					}
+					_ = client.Close()
 				}
 			}
 			if pid == 0 {
@@ -7984,14 +7986,36 @@ func restartSnapshotSubcmds() []*cobra.Command {
 			// If all three fail, emit the no-jsonl hint and return.
 			var jsonlPath string
 			if explicit, _ := cmd.Flags().GetString("jsonl"); explicit != "" {
+				// Pre-flight: stat the explicit path so typos surface with a
+				// targeted hint instead of being misdiagnosed as an extract
+				// failure. ExtractConversation's own error would misdirect
+				// toward permission/corruption remediation.
+				if _, statErr := os.Stat(explicit); os.IsNotExist(statErr) {
+					cli.EmitStderr([]cli.Hint{cli.SnapshotSaveJSONLNotFoundHint(explicit)}, flagQuiet, flagJSON)
+					return fmt.Errorf("jsonl path not found: %s", explicit)
+				}
 				jsonlPath = explicit
 			} else {
 				jsonlPath, err = restart.FindSessionJSONL(claudeDir, pid)
 				if err != nil {
-					if fb, ferr := restart.FindLatestJSONLForCwd(claudeDir, idFile.Worktree); ferr == nil && fb != "" {
-						jsonlPath = fb
+					// Layer 3: mtime fallback. Track fallback diagnostics so
+					// the no-jsonl hint can explain exactly WHY the fallback
+					// didn't succeed (dir missing vs empty vs no worktree).
+					noJSONLCtx := cli.SnapshotSaveNoJSONLContext{}
+					if idFile.Worktree == "" {
+						noJSONLCtx.WorktreeMissing = true
 					} else {
-						cli.EmitStderr([]cli.Hint{cli.SnapshotSaveNoJSONLHint(pid, claudeDir)}, flagQuiet, flagJSON)
+						fb, ferr := restart.FindLatestJSONLForCwd(claudeDir, idFile.Worktree)
+						if ferr == nil && fb != "" {
+							jsonlPath = fb
+						} else if ferr != nil {
+							noJSONLCtx.ProjectDirReadErr = ferr
+						} else {
+							noJSONLCtx.ProjectDirEmpty = true
+						}
+					}
+					if jsonlPath == "" {
+						cli.EmitStderr([]cli.Hint{cli.SnapshotSaveNoJSONLHint(pid, claudeDir, noJSONLCtx)}, flagQuiet, flagJSON)
 						return fmt.Errorf("find session JSONL: %w", err)
 					}
 				}

--- a/cmd/thrum/main.go
+++ b/cmd/thrum/main.go
@@ -7964,6 +7964,7 @@ func restartSnapshotSubcmds() []*cobra.Command {
 				}
 			}
 			if pid == 0 {
+				cli.EmitStderr([]cli.Hint{cli.SnapshotSaveNoPIDHint(agentName)}, flagQuiet, flagJSON)
 				return fmt.Errorf("no agent PID found for %s — ensure agent is registered with an agent PID", agentName)
 			}
 
@@ -7972,9 +7973,28 @@ func restartSnapshotSubcmds() []*cobra.Command {
 				return fmt.Errorf("resolve home directory: %w", err)
 			}
 			claudeDir := filepath.Join(homeDir, ".claude")
-			jsonlPath, err := restart.FindSessionJSONL(claudeDir, pid)
-			if err != nil {
-				return fmt.Errorf("find session JSONL: %w", err)
+
+			// Resolution order (thrum-ufv5.7):
+			//   1. --jsonl <path> flag — explicit caller override, skip auto-detect.
+			//   2. restart.FindSessionJSONL — PID-based lookup (primary path).
+			//   3. restart.FindLatestJSONLForCwd — mtime fallback using the
+			//      worktree path from the identity file. Covers the case where
+			//      ~/.claude/sessions/<pid>.json is missing or stale but the
+			//      project dir still has the current conversation JSONL.
+			// If all three fail, emit the no-jsonl hint and return.
+			var jsonlPath string
+			if explicit, _ := cmd.Flags().GetString("jsonl"); explicit != "" {
+				jsonlPath = explicit
+			} else {
+				jsonlPath, err = restart.FindSessionJSONL(claudeDir, pid)
+				if err != nil {
+					if fb, ferr := restart.FindLatestJSONLForCwd(claudeDir, idFile.Worktree); ferr == nil && fb != "" {
+						jsonlPath = fb
+					} else {
+						cli.EmitStderr([]cli.Hint{cli.SnapshotSaveNoJSONLHint(pid, claudeDir)}, flagQuiet, flagJSON)
+						return fmt.Errorf("find session JSONL: %w", err)
+					}
+				}
 			}
 
 			cfg, _ := config.LoadThrumConfig(thrumDir)
@@ -7982,6 +8002,7 @@ func restartSnapshotSubcmds() []*cobra.Command {
 
 			conversation, err := restart.ExtractConversation(jsonlPath, maxLines)
 			if err != nil {
+				cli.EmitStderr([]cli.Hint{cli.SnapshotSaveExtractFailedHint(jsonlPath)}, flagQuiet, flagJSON)
 				return fmt.Errorf("extract conversation: %w", err)
 			}
 
@@ -8003,6 +8024,7 @@ func restartSnapshotSubcmds() []*cobra.Command {
 		},
 	}
 	saveCmd.Flags().String("reason", "self-initiated", "Reason for restart")
+	saveCmd.Flags().String("jsonl", "", "Explicit path to Claude conversation JSONL (bypasses auto-detect; use when ls ~/.claude/projects/<slug>/ shows the correct file)")
 
 	restoreCmd := &cobra.Command{
 		Use:   "restore",

--- a/internal/cli/hint_sources_snapshot.go
+++ b/internal/cli/hint_sources_snapshot.go
@@ -80,8 +80,11 @@ func SnapshotSaveNoPIDHint(agentName string) Hint {
 }
 
 // SnapshotSaveExtractFailedHint is emitted when restart.ExtractConversation
-// failed — the JSONL path resolved but reading or parsing it errored.
-// Typically permissions or file-corruption issues.
+// failed — the JSONL path is confirmed to exist (the os.Stat pre-flight
+// passed, or restart's auto-detect found it on disk), but the reader
+// couldn't open or scan it. Failure is therefore due to read permissions
+// or content corruption, NOT a typo'd path (which fires
+// SnapshotSaveJSONLNotFoundHint instead).
 func SnapshotSaveExtractFailedHint(jsonlPath string) Hint {
 	return Hint{
 		Code:     HintSnapshotSaveExtractFailed,

--- a/internal/cli/hint_sources_snapshot.go
+++ b/internal/cli/hint_sources_snapshot.go
@@ -11,6 +11,25 @@ import "fmt"
 // with no HintCtx fixtures and make the error-attachment pattern obvious at
 // the call site.
 
+// SnapshotSaveNoJSONLContext lets the command site explain WHY auto-detect
+// failed so the rendered hint can be specific about the root cause. All
+// fields are optional; leaving them zero produces the generic catchall
+// message. The three fields are mutually exclusive in practice but aren't
+// enforced so — if ever needed — a call site can layer context.
+type SnapshotSaveNoJSONLContext struct {
+	// WorktreeMissing is true when idFile.Worktree was empty and the mtime
+	// fallback therefore could not be attempted at all. Drives the operator
+	// toward re-registering the agent with a populated worktree field.
+	WorktreeMissing bool
+	// ProjectDirReadErr is the error returned by FindLatestJSONLForCwd when
+	// the project dir itself could not be read (ENOENT, permission denied,
+	// etc). Distinct from an empty project dir — see ProjectDirEmpty.
+	ProjectDirReadErr error
+	// ProjectDirEmpty is true when the project dir exists but holds no
+	// .jsonl files. Distinct from a read error — Claude may have rotated.
+	ProjectDirEmpty bool
+}
+
 // SnapshotSaveNoJSONLHint is emitted when all three JSONL resolution layers
 // failed (PID-based lookup, mtime fallback against the worktree project dir,
 // and no explicit --jsonl path). Common causes:
@@ -18,16 +37,28 @@ import "fmt"
 //   - Claude rotated the project directory (session PID no longer current)
 //   - identity file's agent_pid is stale and points at a dead process
 //   - worktree path doesn't match Claude's project-slug encoding
-func SnapshotSaveNoJSONLHint(pid int, claudeDir string) Hint {
+//   - identity file's worktree field is empty (mtime fallback disabled)
+//
+// Context is optional; pass the zero value to keep the generic message.
+func SnapshotSaveNoJSONLHint(pid int, claudeDir string, ctx SnapshotSaveNoJSONLContext) Hint {
+	msg := fmt.Sprintf("no Claude JSONL found for PID %d under %s (PID lookup + mtime fallback both failed)", pid, claudeDir)
+	switch {
+	case ctx.WorktreeMissing:
+		msg = fmt.Sprintf("no Claude JSONL found for PID %d under %s (mtime fallback skipped — identity file is missing the 'worktree' field)", pid, claudeDir)
+	case ctx.ProjectDirReadErr != nil:
+		msg = fmt.Sprintf("no Claude JSONL found for PID %d under %s (project dir lookup failed: %v)", pid, claudeDir, ctx.ProjectDirReadErr)
+	case ctx.ProjectDirEmpty:
+		msg = fmt.Sprintf("no Claude JSONL found for PID %d under %s (project dir exists but contains no .jsonl files)", pid, claudeDir)
+	}
 	return Hint{
 		Code:     HintSnapshotSaveNoJSONL,
 		Severity: SeverityWarn,
-		Message:  fmt.Sprintf("no Claude JSONL found for PID %d under %s (PID lookup + mtime fallback both failed)", pid, claudeDir),
+		Message:  msg,
 		Options: []Option{
-			{Label: "locate", Cmd: fmt.Sprintf("ls %s/projects/ | grep -i <worktree-dir>", claudeDir), Note: "find the encoded project slug for your worktree"},
+			{Label: "locate", Cmd: fmt.Sprintf("ls \"%s/projects/\" | grep -i <worktree-dir>", claudeDir), Note: "find the encoded project slug for your worktree"},
 			{Label: "override", Cmd: "thrum tmux snapshot save --jsonl <path>", Note: "supply the JSONL path directly (bypass auto-detect)"},
-			{Label: "verify-pid", Cmd: fmt.Sprintf("ls %s/sessions/%d.json", claudeDir, pid), Note: "confirm whether Claude recorded the agent's session"},
-			{Label: "re-register", Cmd: "thrum quickstart --name <name> --role <role> --module <module> --runtime claude --force", Note: "if agent_pid is stale"},
+			{Label: "verify-pid", Cmd: fmt.Sprintf("ls \"%s/sessions/%d.json\"", claudeDir, pid), Note: "confirm whether Claude recorded the agent's session"},
+			{Label: "re-register", Cmd: "thrum quickstart --name <name> --role <role> --module <module> --runtime claude --force", Note: "if agent_pid is stale or worktree is missing"},
 			{Label: "check-runtime", Cmd: "thrum whoami", Note: "confirm runtime=claude; snapshot save only supports claude today"},
 		},
 	}
@@ -57,9 +88,26 @@ func SnapshotSaveExtractFailedHint(jsonlPath string) Hint {
 		Severity: SeverityWarn,
 		Message:  fmt.Sprintf("failed to extract conversation from %s", jsonlPath),
 		Options: []Option{
-			{Label: "inspect", Cmd: fmt.Sprintf("head -5 %s", jsonlPath)},
-			{Label: "check-perms", Cmd: fmt.Sprintf("ls -l %s", jsonlPath)},
-			{Label: "check-format", Cmd: fmt.Sprintf("wc -l %s", jsonlPath), Note: "empty or zero-line file signals truncation"},
+			{Label: "inspect", Cmd: fmt.Sprintf("head -5 \"%s\"", jsonlPath)},
+			{Label: "check-perms", Cmd: fmt.Sprintf("ls -l \"%s\"", jsonlPath)},
+			{Label: "check-format", Cmd: fmt.Sprintf("wc -l \"%s\"", jsonlPath), Note: "empty or zero-line file signals truncation"},
+		},
+	}
+}
+
+// SnapshotSaveJSONLNotFoundHint is emitted when --jsonl <path> was supplied
+// but os.Stat reports the path does not exist. Distinct from
+// SnapshotSaveExtractFailedHint so the remediation focuses on the typo /
+// resolution case rather than permissions or corruption.
+func SnapshotSaveJSONLNotFoundHint(jsonlPath string) Hint {
+	return Hint{
+		Code:     HintSnapshotSaveJSONLNotFound,
+		Severity: SeverityWarn,
+		Message:  fmt.Sprintf("--jsonl path not found: %s", jsonlPath),
+		Options: []Option{
+			{Label: "verify", Cmd: fmt.Sprintf("ls -l \"%s\"", jsonlPath), Note: "confirm the exact path (typo? symlink?)"},
+			{Label: "locate", Cmd: "ls \"$HOME/.claude/projects/\"", Note: "browse Claude's project dirs to find the right JSONL"},
+			{Label: "auto-detect", Cmd: "thrum tmux snapshot save", Note: "drop --jsonl to let auto-detect + mtime fallback try"},
 		},
 	}
 }

--- a/internal/cli/hint_sources_snapshot.go
+++ b/internal/cli/hint_sources_snapshot.go
@@ -1,0 +1,65 @@
+package cli
+
+import "fmt"
+
+// Snapshot-save hints differ structurally from tmux.create / init hints: they
+// fire on error return paths, not pre/post detection. We therefore do NOT
+// register them via RegisterHintSource — instead the command site calls these
+// pure builders when it knows it is returning an error and wants to attach a
+// remediation trailer via EmitStderr. Keeping them as free-standing Hint
+// constructors (rather than a HintSource) means they are trivially unit-testable
+// with no HintCtx fixtures and make the error-attachment pattern obvious at
+// the call site.
+
+// SnapshotSaveNoJSONLHint is emitted when all three JSONL resolution layers
+// failed (PID-based lookup, mtime fallback against the worktree project dir,
+// and no explicit --jsonl path). Common causes:
+//   - agent is running under a non-Claude runtime
+//   - Claude rotated the project directory (session PID no longer current)
+//   - identity file's agent_pid is stale and points at a dead process
+//   - worktree path doesn't match Claude's project-slug encoding
+func SnapshotSaveNoJSONLHint(pid int, claudeDir string) Hint {
+	return Hint{
+		Code:     HintSnapshotSaveNoJSONL,
+		Severity: SeverityWarn,
+		Message:  fmt.Sprintf("no Claude JSONL found for PID %d under %s (PID lookup + mtime fallback both failed)", pid, claudeDir),
+		Options: []Option{
+			{Label: "locate", Cmd: fmt.Sprintf("ls %s/projects/ | grep -i <worktree-dir>", claudeDir), Note: "find the encoded project slug for your worktree"},
+			{Label: "override", Cmd: "thrum tmux snapshot save --jsonl <path>", Note: "supply the JSONL path directly (bypass auto-detect)"},
+			{Label: "verify-pid", Cmd: fmt.Sprintf("ls %s/sessions/%d.json", claudeDir, pid), Note: "confirm whether Claude recorded the agent's session"},
+			{Label: "re-register", Cmd: "thrum quickstart --name <name> --role <role> --module <module> --runtime claude --force", Note: "if agent_pid is stale"},
+			{Label: "check-runtime", Cmd: "thrum whoami", Note: "confirm runtime=claude; snapshot save only supports claude today"},
+		},
+	}
+}
+
+// SnapshotSaveNoPIDHint is emitted when the save command could not resolve
+// the agent's PID — neither the identity file nor the daemon's agent.list
+// returned a non-zero AgentPID for the agent name.
+func SnapshotSaveNoPIDHint(agentName string) Hint {
+	return Hint{
+		Code:     HintSnapshotSaveNoPID,
+		Severity: SeverityWarn,
+		Message:  fmt.Sprintf("no agent PID resolvable for %s (identity file and daemon both returned 0)", agentName),
+		Options: []Option{
+			{Label: "re-register", Cmd: fmt.Sprintf("thrum quickstart --name %s --role <role> --module <module> --runtime claude --force", agentName), Note: "writes current PID into identity file"},
+			{Label: "verify-daemon", Cmd: "thrum status"},
+		},
+	}
+}
+
+// SnapshotSaveExtractFailedHint is emitted when restart.ExtractConversation
+// failed — the JSONL path resolved but reading or parsing it errored.
+// Typically permissions or file-corruption issues.
+func SnapshotSaveExtractFailedHint(jsonlPath string) Hint {
+	return Hint{
+		Code:     HintSnapshotSaveExtractFailed,
+		Severity: SeverityWarn,
+		Message:  fmt.Sprintf("failed to extract conversation from %s", jsonlPath),
+		Options: []Option{
+			{Label: "inspect", Cmd: fmt.Sprintf("head -5 %s", jsonlPath)},
+			{Label: "check-perms", Cmd: fmt.Sprintf("ls -l %s", jsonlPath)},
+			{Label: "check-format", Cmd: fmt.Sprintf("wc -l %s", jsonlPath), Note: "empty or zero-line file signals truncation"},
+		},
+	}
+}

--- a/internal/cli/hint_sources_snapshot_test.go
+++ b/internal/cli/hint_sources_snapshot_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSnapshotSaveNoPIDHint(t *testing.T) {
+	h := SnapshotSaveNoPIDHint("impl_team_fix")
+
+	if h.Code != HintSnapshotSaveNoPID {
+		t.Errorf("Code = %q, want %q", h.Code, HintSnapshotSaveNoPID)
+	}
+	if h.Severity != SeverityWarn {
+		t.Errorf("Severity = %q, want warn", h.Severity)
+	}
+	if !strings.Contains(h.Message, "impl_team_fix") {
+		t.Errorf("Message should name the agent: %q", h.Message)
+	}
+	if len(h.Options) < 2 {
+		t.Errorf("expected ≥2 remediation options; got %d", len(h.Options))
+	}
+	// Remediation must include a re-register command with the agent name baked in.
+	found := false
+	for _, o := range h.Options {
+		if strings.Contains(o.Cmd, "thrum quickstart --name impl_team_fix") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected re-register option referencing agent name; options: %+v", h.Options)
+	}
+	if h.AllowForce {
+		t.Error("snapshot.save.no-pid should be hard refusal; AllowForce must be false")
+	}
+}
+
+func TestSnapshotSaveNoJSONLHint(t *testing.T) {
+	h := SnapshotSaveNoJSONLHint(91614, "/home/leon/.claude")
+
+	if h.Code != HintSnapshotSaveNoJSONL {
+		t.Errorf("Code = %q, want %q", h.Code, HintSnapshotSaveNoJSONL)
+	}
+	if h.Severity != SeverityWarn {
+		t.Errorf("Severity = %q, want warn", h.Severity)
+	}
+	if !strings.Contains(h.Message, "91614") {
+		t.Errorf("Message should name the PID: %q", h.Message)
+	}
+	if !strings.Contains(h.Message, "/home/leon/.claude") {
+		t.Errorf("Message should name the claude dir: %q", h.Message)
+	}
+	// Surface the full options map for label-keyed assertions below.
+	byLabel := map[string]Option{}
+	for _, o := range h.Options {
+		byLabel[o.Label] = o
+	}
+	// locate: must reference the projects dir so the operator can find
+	// their worktree's encoded slug.
+	if locate, ok := byLabel["locate"]; !ok {
+		t.Error("expected 'locate' option pointing at ~/.claude/projects/")
+	} else if !strings.Contains(locate.Cmd, "projects/") {
+		t.Errorf("locate.Cmd should reference projects/ dir; got %q", locate.Cmd)
+	}
+	// override: the --jsonl escape hatch. Must be present so operators
+	// have a direct remediation when auto-detect fails — this is the
+	// key thrum-ufv5.7 UX fix.
+	if override, ok := byLabel["override"]; !ok {
+		t.Error("expected 'override' option with --jsonl flag")
+	} else if !strings.Contains(override.Cmd, "--jsonl") {
+		t.Errorf("override.Cmd should mention --jsonl flag; got %q", override.Cmd)
+	}
+	// verify-pid: must reference the PID-specific session file.
+	if vp, ok := byLabel["verify-pid"]; !ok {
+		t.Error("expected 'verify-pid' option")
+	} else if !strings.Contains(vp.Cmd, "91614.json") {
+		t.Errorf("verify-pid.Cmd should reference sessions/<pid>.json; got %q", vp.Cmd)
+	}
+	if h.AllowForce {
+		t.Error("snapshot.save.no-jsonl should be hard refusal; AllowForce must be false")
+	}
+}
+
+func TestSnapshotSaveExtractFailedHint(t *testing.T) {
+	jsonl := "/home/leon/.claude/projects/-Users-leon-test/sess_abc.jsonl"
+	h := SnapshotSaveExtractFailedHint(jsonl)
+
+	if h.Code != HintSnapshotSaveExtractFailed {
+		t.Errorf("Code = %q, want %q", h.Code, HintSnapshotSaveExtractFailed)
+	}
+	if h.Severity != SeverityWarn {
+		t.Errorf("Severity = %q, want warn", h.Severity)
+	}
+	if !strings.Contains(h.Message, jsonl) {
+		t.Errorf("Message should name the JSONL path: %q", h.Message)
+	}
+	// Each diagnostic option should reference the JSONL path so copy/paste works.
+	for _, o := range h.Options {
+		if !strings.Contains(o.Cmd, jsonl) {
+			t.Errorf("option %q Cmd should reference JSONL path for copy/paste; got %q", o.Label, o.Cmd)
+		}
+	}
+	if h.AllowForce {
+		t.Error("snapshot.save.extract-failed should be hard refusal; AllowForce must be false")
+	}
+}
+
+func TestSnapshotHints_RenderTextContainsCodeAndMessage(t *testing.T) {
+	// Render through the real text renderer to lock the trailer shape.
+	hints := []Hint{
+		SnapshotSaveNoPIDHint("impl_x"),
+		SnapshotSaveNoJSONLHint(123, "/c"),
+		SnapshotSaveExtractFailedHint("/c/sess.jsonl"),
+	}
+	var buf bytes.Buffer
+	RenderText(hints, &buf)
+	out := buf.String()
+
+	for _, code := range []string{
+		HintSnapshotSaveNoPID,
+		HintSnapshotSaveNoJSONL,
+		HintSnapshotSaveExtractFailed,
+	} {
+		if !strings.Contains(out, "["+code+"]") {
+			t.Errorf("rendered output missing code marker [%s]; output:\n%s", code, out)
+		}
+	}
+	// Warn severity should always prefix each hint.
+	if strings.Count(out, "warn [") < 3 {
+		t.Errorf("expected 3 warn-level rendered hints; output:\n%s", out)
+	}
+}
+
+func TestSnapshotHints_RegisteredInCanonicalList(t *testing.T) {
+	// Guard against forgetting to append a new code to AllHintCodes —
+	// downstream L3 format/uniqueness tests rely on that slice.
+	codes := map[string]bool{}
+	for _, c := range AllHintCodes {
+		codes[c] = true
+	}
+	for _, want := range []string{
+		HintSnapshotSaveNoPID,
+		HintSnapshotSaveNoJSONL,
+		HintSnapshotSaveExtractFailed,
+	} {
+		if !codes[want] {
+			t.Errorf("code %q is not in AllHintCodes", want)
+		}
+	}
+}

--- a/internal/cli/hint_sources_snapshot_test.go
+++ b/internal/cli/hint_sources_snapshot_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -38,7 +39,7 @@ func TestSnapshotSaveNoPIDHint(t *testing.T) {
 }
 
 func TestSnapshotSaveNoJSONLHint(t *testing.T) {
-	h := SnapshotSaveNoJSONLHint(91614, "/home/leon/.claude")
+	h := SnapshotSaveNoJSONLHint(91614, "/home/leon/.claude", SnapshotSaveNoJSONLContext{})
 
 	if h.Code != HintSnapshotSaveNoJSONL {
 		t.Errorf("Code = %q, want %q", h.Code, HintSnapshotSaveNoJSONL)
@@ -111,8 +112,9 @@ func TestSnapshotHints_RenderTextContainsCodeAndMessage(t *testing.T) {
 	// Render through the real text renderer to lock the trailer shape.
 	hints := []Hint{
 		SnapshotSaveNoPIDHint("impl_x"),
-		SnapshotSaveNoJSONLHint(123, "/c"),
+		SnapshotSaveNoJSONLHint(123, "/c", SnapshotSaveNoJSONLContext{}),
 		SnapshotSaveExtractFailedHint("/c/sess.jsonl"),
+		SnapshotSaveJSONLNotFoundHint("/c/missing.jsonl"),
 	}
 	var buf bytes.Buffer
 	RenderText(hints, &buf)
@@ -122,14 +124,15 @@ func TestSnapshotHints_RenderTextContainsCodeAndMessage(t *testing.T) {
 		HintSnapshotSaveNoPID,
 		HintSnapshotSaveNoJSONL,
 		HintSnapshotSaveExtractFailed,
+		HintSnapshotSaveJSONLNotFound,
 	} {
 		if !strings.Contains(out, "["+code+"]") {
 			t.Errorf("rendered output missing code marker [%s]; output:\n%s", code, out)
 		}
 	}
 	// Warn severity should always prefix each hint.
-	if strings.Count(out, "warn [") < 3 {
-		t.Errorf("expected 3 warn-level rendered hints; output:\n%s", out)
+	if strings.Count(out, "warn [") < 4 {
+		t.Errorf("expected 4 warn-level rendered hints; output:\n%s", out)
 	}
 }
 
@@ -144,9 +147,89 @@ func TestSnapshotHints_RegisteredInCanonicalList(t *testing.T) {
 		HintSnapshotSaveNoPID,
 		HintSnapshotSaveNoJSONL,
 		HintSnapshotSaveExtractFailed,
+		HintSnapshotSaveJSONLNotFound,
 	} {
 		if !codes[want] {
 			t.Errorf("code %q is not in AllHintCodes", want)
 		}
 	}
 }
+
+func TestSnapshotSaveNoJSONLHint_ContextVariants(t *testing.T) {
+	// Each context variant must produce a message that distinguishes
+	// the root cause. Reviewers flagged conflation between
+	// "dir-missing-or-readerror" and "dir-empty" — this guard locks
+	// three distinct message tails so the operator knows which branch
+	// actually failed.
+	cases := []struct {
+		name    string
+		ctx     SnapshotSaveNoJSONLContext
+		substr  string
+		absent  string // must NOT appear — keeps messages from double-reporting
+	}{
+		{
+			name:   "worktree-missing",
+			ctx:    SnapshotSaveNoJSONLContext{WorktreeMissing: true},
+			substr: "missing the 'worktree' field",
+			absent: "PID lookup + mtime fallback",
+		},
+		{
+			name:   "project-dir-read-err",
+			ctx:    SnapshotSaveNoJSONLContext{ProjectDirReadErr: fmtError("permission denied")},
+			substr: "project dir lookup failed: permission denied",
+			absent: "PID lookup + mtime fallback",
+		},
+		{
+			name:   "project-dir-empty",
+			ctx:    SnapshotSaveNoJSONLContext{ProjectDirEmpty: true},
+			substr: "project dir exists but contains no .jsonl files",
+			absent: "PID lookup + mtime fallback",
+		},
+		{
+			name:   "generic (zero context)",
+			ctx:    SnapshotSaveNoJSONLContext{},
+			substr: "PID lookup + mtime fallback both failed",
+			absent: "missing the 'worktree' field",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := SnapshotSaveNoJSONLHint(42, "/c", tc.ctx)
+			if !strings.Contains(h.Message, tc.substr) {
+				t.Errorf("Message should contain %q; got %q", tc.substr, h.Message)
+			}
+			if tc.absent != "" && strings.Contains(h.Message, tc.absent) {
+				t.Errorf("Message should NOT contain %q; got %q", tc.absent, h.Message)
+			}
+		})
+	}
+}
+
+func TestSnapshotSaveJSONLNotFoundHint(t *testing.T) {
+	h := SnapshotSaveJSONLNotFoundHint("/tmp/typo-path.jsonl")
+	if h.Code != HintSnapshotSaveJSONLNotFound {
+		t.Errorf("Code = %q, want %q", h.Code, HintSnapshotSaveJSONLNotFound)
+	}
+	if h.Severity != SeverityWarn {
+		t.Errorf("Severity = %q, want warn", h.Severity)
+	}
+	if !strings.Contains(h.Message, "/tmp/typo-path.jsonl") {
+		t.Errorf("Message should name the supplied path; got %q", h.Message)
+	}
+	// auto-detect escape hatch must be suggested (ship-worthy remediation
+	// when the operator wants to retry without --jsonl).
+	byLabel := map[string]Option{}
+	for _, o := range h.Options {
+		byLabel[o.Label] = o
+	}
+	if ad, ok := byLabel["auto-detect"]; !ok {
+		t.Error("expected 'auto-detect' option suggesting drop --jsonl")
+	} else if strings.Contains(ad.Cmd, "--jsonl") {
+		t.Errorf("auto-detect Cmd should OMIT --jsonl; got %q", ad.Cmd)
+	}
+}
+
+// fmtError is a tiny helper that returns a printable error without pulling
+// in errors.New at the top of every caller. Keeps the context-variant
+// fixture one line shorter.
+func fmtError(s string) error { return fmt.Errorf("%s", s) }

--- a/internal/cli/hintcodes.go
+++ b/internal/cli/hintcodes.go
@@ -64,10 +64,20 @@ const HintSnapshotSaveNoJSONL = "snapshot.save.no-jsonl"
 const HintSnapshotSaveNoPID = "snapshot.save.no-pid"
 
 // HintSnapshotSaveExtractFailed — JSONL located but restart.ExtractConversation
-// failed to read/parse it. Usually a file-permission or corruption issue.
+// failed to read/parse it. Usually a file-permission or corruption issue,
+// or a file-not-found when a --jsonl override points at a path that exists
+// but the reader can't parse (e.g. non-JSONL content).
 // Origin: same release-test sweep as HintSnapshotSaveNoJSONL. Severity: warn;
 // hard refusal.
 const HintSnapshotSaveExtractFailed = "snapshot.save.extract-failed"
+
+// HintSnapshotSaveJSONLNotFound — the --jsonl <path> supplied by the caller
+// does not exist on disk. Distinguished from HintSnapshotSaveExtractFailed
+// (which fires when the file DOES exist but can't be read/parsed) so the
+// remediation can focus on the typo/path-resolution case instead of
+// permissions or corruption. Origin: dual-review thrum-ufv5.7 finding #2.
+// Severity: warn; hard refusal.
+const HintSnapshotSaveJSONLNotFound = "snapshot.save.jsonl-not-found"
 
 // RecipientStaleThreshold is the send-side stale cutoff. Exported per
 // spec §4 as a tunable; becomes a config key in Phase C if the pilot
@@ -88,4 +98,5 @@ var AllHintCodes = []string{
 	HintSnapshotSaveNoJSONL,
 	HintSnapshotSaveNoPID,
 	HintSnapshotSaveExtractFailed,
+	HintSnapshotSaveJSONLNotFound,
 }

--- a/internal/cli/hintcodes.go
+++ b/internal/cli/hintcodes.go
@@ -47,6 +47,28 @@ const HintSendRecipientStale = "send.recipient-stale"
 // init→quickstart sequence. Info.
 const HintInitNextQuickstart = "init.next-quickstart"
 
+// HintSnapshotSaveNoJSONL — thrum tmux snapshot save could not locate the
+// Claude Code JSONL for the resolved agent PID. Covers both underlying
+// restart.FindSessionJSONL failures: (a) missing ~/.claude/sessions/<pid>.json,
+// (b) session file resolved but the per-CWD JSONL under ~/.claude/projects/
+// is absent. Origin: release-test sweep 2026-04-21 — @impl_team_fix hit a
+// save failure that /thrum:restart step 3 swallowed silently (no exit-code
+// check), pre-fix by coordinator commit 27e84c39. Severity: warn; hard
+// refusal (no --force recovery — the JSONL either exists or it doesn't).
+const HintSnapshotSaveNoJSONL = "snapshot.save.no-jsonl"
+
+// HintSnapshotSaveNoPID — identity file is missing agent_pid AND the daemon
+// lookup returned no PID for the agent. Either the agent isn't registered
+// yet or the identity file predates the AgentPID column. Origin: same
+// release-test sweep as HintSnapshotSaveNoJSONL. Severity: warn; hard refusal.
+const HintSnapshotSaveNoPID = "snapshot.save.no-pid"
+
+// HintSnapshotSaveExtractFailed — JSONL located but restart.ExtractConversation
+// failed to read/parse it. Usually a file-permission or corruption issue.
+// Origin: same release-test sweep as HintSnapshotSaveNoJSONL. Severity: warn;
+// hard refusal.
+const HintSnapshotSaveExtractFailed = "snapshot.save.extract-failed"
+
 // RecipientStaleThreshold is the send-side stale cutoff. Exported per
 // spec §4 as a tunable; becomes a config key in Phase C if the pilot
 // signals that 30 minutes is the wrong threshold.
@@ -63,4 +85,7 @@ var AllHintCodes = []string{
 	HintTmuxCreateIdentityReplaced,
 	HintSendRecipientStale,
 	HintInitNextQuickstart,
+	HintSnapshotSaveNoJSONL,
+	HintSnapshotSaveNoPID,
+	HintSnapshotSaveExtractFailed,
 }

--- a/internal/cli/hintcodes_test.go
+++ b/internal/cli/hintcodes_test.go
@@ -34,13 +34,15 @@ func TestNoDuplicateCodes(t *testing.T) {
 	}
 }
 
-// TestCatalogSize locks the pilot catalog size. Bump when adding codes
-// in a deliberate review. Pilot catalog is 8:
+// TestCatalogSize locks the catalog size. Bump when adding codes in a
+// deliberate review. Current catalog is 11:
 // 6 tmux.create (session-exists, not-a-worktree, identity-exists-alive,
 // identity-exists-stale, next-launch, identity-replaced) +
-// send.recipient-stale + init.next-quickstart.
+// send.recipient-stale + init.next-quickstart +
+// 3 snapshot.save (no-jsonl, no-pid, extract-failed) — added for
+// thrum-ufv5.7 to surface silent failures of `thrum tmux snapshot save`.
 func TestCatalogSize(t *testing.T) {
-	const expected = 8
+	const expected = 11
 	if got := len(AllHintCodes); got != expected {
 		t.Errorf("AllHintCodes size = %d, want %d (update this test deliberately when catalog grows)", got, expected)
 	}
@@ -66,6 +68,9 @@ var constNameForCode = map[string]string{
 	HintTmuxCreateIdentityReplaced:    "HintTmuxCreateIdentityReplaced",
 	HintSendRecipientStale:            "HintSendRecipientStale",
 	HintInitNextQuickstart:            "HintInitNextQuickstart",
+	HintSnapshotSaveNoJSONL:           "HintSnapshotSaveNoJSONL",
+	HintSnapshotSaveNoPID:             "HintSnapshotSaveNoPID",
+	HintSnapshotSaveExtractFailed:     "HintSnapshotSaveExtractFailed",
 }
 
 // TestEveryCodeHasSourceReference ensures every code in AllHintCodes is

--- a/internal/cli/hintcodes_test.go
+++ b/internal/cli/hintcodes_test.go
@@ -35,14 +35,17 @@ func TestNoDuplicateCodes(t *testing.T) {
 }
 
 // TestCatalogSize locks the catalog size. Bump when adding codes in a
-// deliberate review. Current catalog is 11:
+// deliberate review. Current catalog is 12:
 // 6 tmux.create (session-exists, not-a-worktree, identity-exists-alive,
-// identity-exists-stale, next-launch, identity-replaced) +
-// send.recipient-stale + init.next-quickstart +
-// 3 snapshot.save (no-jsonl, no-pid, extract-failed) — added for
-// thrum-ufv5.7 to surface silent failures of `thrum tmux snapshot save`.
+// identity-exists-stale, next-launch, identity-replaced),
+// send.recipient-stale, init.next-quickstart, and
+// 4 snapshot.save (no-jsonl, no-pid, extract-failed, jsonl-not-found)
+// added for thrum-ufv5.7 to surface silent failures of
+// thrum tmux snapshot save, where jsonl-not-found arrived in the
+// dual-review fixup to distinguish typo'd --jsonl paths from read/parse
+// failures.
 func TestCatalogSize(t *testing.T) {
-	const expected = 11
+	const expected = 12
 	if got := len(AllHintCodes); got != expected {
 		t.Errorf("AllHintCodes size = %d, want %d (update this test deliberately when catalog grows)", got, expected)
 	}
@@ -71,6 +74,7 @@ var constNameForCode = map[string]string{
 	HintSnapshotSaveNoJSONL:           "HintSnapshotSaveNoJSONL",
 	HintSnapshotSaveNoPID:             "HintSnapshotSaveNoPID",
 	HintSnapshotSaveExtractFailed:     "HintSnapshotSaveExtractFailed",
+	HintSnapshotSaveJSONLNotFound:     "HintSnapshotSaveJSONLNotFound",
 }
 
 // TestEveryCodeHasSourceReference ensures every code in AllHintCodes is

--- a/internal/restart/restart.go
+++ b/internal/restart/restart.go
@@ -33,7 +33,7 @@ type contentBlock struct {
 // user+assistant text only (no tool use, thinking, sidechains, or non-message types).
 // Returns formatted conversation text truncated to maxLines.
 func ExtractConversation(jsonlPath string, maxLines int) (string, error) {
-	f, err := os.Open(jsonlPath) // #nosec G304 -- path from internal session lookup
+	f, err := os.Open(jsonlPath) // #nosec G304 -- path from internal session lookup, mtime-fallback glob, or --jsonl flag (CLI-local tool, trust boundary is the local user)
 	if err != nil {
 		return "", fmt.Errorf("open JSONL: %w", err)
 	}

--- a/internal/restart/restart.go
+++ b/internal/restart/restart.go
@@ -192,6 +192,46 @@ func encodeCwd(cwd string) string {
 	return "-" + encoded
 }
 
+// FindLatestJSONLForCwd picks the most-recently-modified .jsonl file under
+// ~/.claude/projects/<encoded-cwd>/, serving as a fallback when PID-based
+// session lookup (FindSessionJSONL) fails. Motivation: Claude Code's per-PID
+// sessions/<pid>.json file may be missing, stale, or pointing at a rotated
+// JSONL; the project directory itself usually still holds a current JSONL,
+// and most-recent-mtime is a good heuristic for "the conversation the agent
+// is actively in".
+//
+// Returns ("", nil) when the project dir exists but contains no .jsonl files
+// — callers treat empty-string as "no fallback available" and emit the
+// no-jsonl hint. A missing project dir is reported as an error so callers
+// can distinguish "dir absent" (agent not running under Claude, or wrong
+// cwd encoding) from "dir present but empty" (unexpected Claude state).
+func FindLatestJSONLForCwd(claudeDir, cwd string) (string, error) {
+	if cwd == "" {
+		return "", fmt.Errorf("cwd required for project-dir fallback")
+	}
+	projectDir := filepath.Join(claudeDir, "projects", encodeCwd(cwd))
+	entries, err := os.ReadDir(projectDir)
+	if err != nil {
+		return "", fmt.Errorf("read project dir %s: %w", projectDir, err)
+	}
+	var bestMTime time.Time
+	var bestPath string
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if bestPath == "" || info.ModTime().After(bestMTime) {
+			bestMTime = info.ModTime()
+			bestPath = filepath.Join(projectDir, e.Name())
+		}
+	}
+	return bestPath, nil
+}
+
 // FormatRestartSnapshot builds the complete snapshot file content.
 func FormatRestartSnapshot(agentName, sessionID, reason, conversation string) string {
 	var out strings.Builder

--- a/internal/restart/restart_test.go
+++ b/internal/restart/restart_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -301,4 +302,61 @@ func TestConsumeInPrime_NotFound(t *testing.T) {
 	thrumDir := t.TempDir()
 	_, err := ConsumeInPrime(thrumDir, "nonexistent")
 	assert.Error(t, err)
+}
+
+func TestFindLatestJSONLForCwd_PicksMostRecent(t *testing.T) {
+	claudeDir := t.TempDir()
+	cwd := "/Users/leon/.workspaces/thrum/team-fix"
+	// encodeCwd produces the slug deterministically; mirror it for fixture setup.
+	slug := "-Users-leon--workspaces-thrum-team-fix"
+	projectDir := filepath.Join(claudeDir, "projects", slug)
+	require.NoError(t, os.MkdirAll(projectDir, 0o750))
+
+	// Write 3 JSONL files with staggered mtimes; oldest first so
+	// os.Chtimes sticks even on filesystems with 1-second resolution.
+	older := filepath.Join(projectDir, "sess-older.jsonl")
+	middle := filepath.Join(projectDir, "sess-middle.jsonl")
+	latest := filepath.Join(projectDir, "sess-latest.jsonl")
+	for _, p := range []string{older, middle, latest} {
+		require.NoError(t, os.WriteFile(p, []byte("{}\n"), 0o600))
+	}
+	base := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(older, base, base))
+	require.NoError(t, os.Chtimes(middle, base.Add(10*time.Minute), base.Add(10*time.Minute)))
+	require.NoError(t, os.Chtimes(latest, base.Add(50*time.Minute), base.Add(50*time.Minute)))
+
+	got, err := FindLatestJSONLForCwd(claudeDir, cwd)
+	require.NoError(t, err)
+	assert.Equal(t, latest, got, "should pick newest-mtime JSONL")
+
+	// Sanity: non-jsonl siblings must be ignored even if newer.
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "notes.txt"), []byte("x"), 0o600))
+	got2, err := FindLatestJSONLForCwd(claudeDir, cwd)
+	require.NoError(t, err)
+	assert.Equal(t, latest, got2, "non-.jsonl files must not outrank the real JSONL")
+}
+
+func TestFindLatestJSONLForCwd_EmptyDir(t *testing.T) {
+	claudeDir := t.TempDir()
+	cwd := "/Users/leon/dev/empty"
+	projectDir := filepath.Join(claudeDir, "projects", "-Users-leon-dev-empty")
+	require.NoError(t, os.MkdirAll(projectDir, 0o750))
+
+	got, err := FindLatestJSONLForCwd(claudeDir, cwd)
+	require.NoError(t, err, "empty dir is not a hard error")
+	assert.Equal(t, "", got, "empty result signals 'no fallback available'")
+}
+
+func TestFindLatestJSONLForCwd_MissingDir(t *testing.T) {
+	claudeDir := t.TempDir() // no projects/ at all
+	_, err := FindLatestJSONLForCwd(claudeDir, "/some/cwd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read project dir")
+}
+
+func TestFindLatestJSONLForCwd_EmptyCwd(t *testing.T) {
+	claudeDir := t.TempDir()
+	_, err := FindLatestJSONLForCwd(claudeDir, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cwd required")
 }


### PR DESCRIPTION
## Summary
- 4 new hint codes (`snapshot.save.no-jsonl` / `no-pid` / `extract-failed` / `jsonl-not-found`) surface previously-silent failures of `thrum tmux snapshot save`; catalog grows from 8 → 12.
- 3-layer JSONL resolution cascade: `--jsonl <path>` flag → `restart.FindSessionJSONL` (PID-based) → new `restart.FindLatestJSONLForCwd` (mtime fallback via identity worktree slug).
- Dual-review addressed over two rounds (0 BLOCKING, 4 IMPORTANT + 4 MINOR in round 1; approved on round 2 with optional F5 polish applied in a third commit).

## Background
Release-test sweep surfaced a silent failure: `/thrum:restart` step 3 called `thrum tmux snapshot save`, which exited non-zero, but the flow proceeded to step 6 without checking the exit code. Leon's fail-fast patch for the flow (`27e84c39` on thrum-dev) covered the immediate exit-code gap. This PR fixes the underlying UX and resolution fragility so any future failure is loud and recoverable.

Most likely @impl_team_fix root cause: `FindSessionJSONL` returned "read session file for PID: no such file" because `~/.claude/sessions/<pid>.json` is only written while a Claude session is actively tracked. The new mtime fallback covers this class — the project dir under `~/.claude/projects/<slug>/` stays live even when the per-PID session file is absent.

## What changed

### Hint codes (`internal/cli/hintcodes.go`, `hint_sources_snapshot.go`)
| Code | Fires when |
|------|-----------|
| `snapshot.save.no-jsonl` | All 3 resolution layers exhausted. Context-aware message distinguishes missing worktree / read-error / empty-dir / generic. |
| `snapshot.save.no-pid` | Identity file has `agent_pid=0` AND daemon lookup returned no-match. |
| `snapshot.save.extract-failed` | JSONL exists but can't be opened or scanned (permissions / corruption). |
| `snapshot.save.jsonl-not-found` | `--jsonl` path supplied but `os.Stat` reports ENOENT (added in review-round-2 to distinguish typo from extract failure). |

All 4 are `SeverityWarn`, `AllowForce=false` (hard refusal). Shape B stderr trailer renders via `cli.EmitStderr`; `THRUM_NO_HINTS=1` and `--quiet` both suppress.

### Resolution cascade (`cmd/thrum/main.go` saveCmd)
```
if --jsonl supplied:
    os.Stat pre-flight → if missing, jsonl-not-found hint
    else use supplied path
else:
    FindSessionJSONL (PID lookup)
    if err:
        if worktree missing → no-jsonl with WorktreeMissing context
        else FindLatestJSONLForCwd (mtime fallback)
            success → use fallback
            read-error → no-jsonl with ProjectDirReadErr context
            empty dir → no-jsonl with ProjectDirEmpty context
```

### Secondary fix: daemon-tolerant no-pid fallback
When `agent_pid=0` forces a daemon-side lookup, daemon connect failures previously returned `connect to daemon: ...` — misleading since the daemon lookup is itself a fallback. Now falls through silently to the `pid==0` refusal so the correct `no-pid` hint renders regardless of daemon availability.

### `#nosec G304` justification updated (restart.go)
`ExtractConversation` now accepts paths from three sources (internal session lookup, mtime-fallback glob, `--jsonl` CLI flag); the nosec comment explicitly enumerates them.

## Tests
- **Unit (internal/cli)**: 9 subtests on hint builders covering code/severity/options/AllowForce, context variants (worktree-missing / project-dir-read-err / project-dir-empty / generic), render-text integration, and catalog registration.
- **Unit (internal/restart)**: 4 subtests on `FindLatestJSONLForCwd` covering newest-pick, empty-dir, missing-dir, empty-cwd paths.
- **L4 integration (cmd/thrum)**: 8 tests exercising the built binary end-to-end — no-jsonl text mode, `THRUM_NO_HINTS` suppression, mtime-fallback happy path, `--jsonl` bypass happy path, no-pid trigger without daemon, extract-failed via `chmod 000`, jsonl-not-found for typo'd paths, worktree-missing context.
- Catalog-size + `TestEveryCodeHasSourceReference` + `TestEveryCodeHasUnitTestReference` updated for the 4 new codes.
- `writeSnapshotTestIdentity` helper extracted so identity fixtures are consistent across all 8 L4 tests.

All `go test -race -count=1 ./internal/cli/... ./internal/restart/... ./cmd/thrum/...` green. Zero lint findings on changed files.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -count=1 ./internal/cli/ ./internal/restart/ ./cmd/thrum/`
- [x] `golangci-lint run ./internal/cli/... ./internal/restart/... ./cmd/thrum/...` (0 findings on changed files)
- [x] Manual repro: delete `~/.claude/sessions/<pid>.json` → save → expect `[snapshot.save.no-jsonl]` stderr trailer
- [x] Manual repro: `--jsonl /bogus/path` → expect `[snapshot.save.jsonl-not-found]`
- [ ] Smoke test after merge: run `thrum tmux snapshot save` in a live Claude session; mtime fallback should transparently succeed even if PID-match would fail

## Commits
- `5faeb77a` — baseline: 3 hints + inline emission + cascade + initial unit/L4 tests
- `acda76f4` — review-round-1 fixes (4 IMPORTANT + 4 MINOR + secondary daemon-tolerance)
- `c2c83c2d` — optional F5 polish from review-round-2 (doc clarification)

Bead: thrum-ufv5.7 (to be closed by @coordinator_main on merge).