### PR TITLE
fix(permission): multi-supervisor threading + pre-send pane recheck (thrum-rfy3)

### DIFF
--- a/internal/daemon/permission/nudge.go
+++ b/internal/daemon/permission/nudge.go
@@ -23,8 +23,11 @@ type NudgeRow struct {
 	AgentName string
 
 	// PatternKey is "runtime.pattern_name", e.g. "cursor.not_in_allowlist".
-	// Stored for display; the actual keystrokes are cached in
-	// ApproveKey/DenyKey.
+	// Format: "<runtime>.<name>" — the dot is load-bearing.
+	// reply.go's paneStillMatches splits on it to re-detect pane state,
+	// and a dotless key fails-closed (skip keystroke) rather than
+	// misroute. Stored for display; the actual keystrokes are cached
+	// in ApproveKey/DenyKey.
 	PatternKey string
 
 	// ApproveKey and DenyKey are the single-invocation keystrokes

--- a/internal/daemon/permission/permission.go
+++ b/internal/daemon/permission/permission.go
@@ -40,6 +40,13 @@ type Permission struct {
 	// sendKeystroke falls back to defaultKeystroke (tmux.SendKeys /
 	// tmux.SendSpecialKey) in that case.
 	keystrokeSender func(target, key string) error
+
+	// paneCapture is injected by reply_test to simulate pane state at
+	// dispatch time. Production leaves it nil; the pre-send pane
+	// recheck falls back to tmux.CapturePane in that case. See
+	// TryResolve's pre-send check for why this seam exists
+	// (thrum-rfy3: race-safe defense-in-depth beyond the atomic claim).
+	paneCapture func(target string, lines int) (string, error)
 }
 
 // New builds a Permission. The state argument may be nil for unit tests
@@ -86,6 +93,16 @@ func (p *Permission) SetClock(now func() time.Time) {
 // reads keystrokeSender under no lock.
 func (p *Permission) SetKeystrokeSenderForTest(fn func(target, key string) error) {
 	p.keystrokeSender = fn
+}
+
+// SetPaneCaptureForTest installs a test-only pane capture function so
+// reply-path tests can simulate pane state at dispatch time without
+// touching real tmux. PRODUCTION CODE MUST NOT CALL THIS. Production
+// uses tmux.CapturePane via the lazy fallback in captureForRecheck.
+//
+// NOT SAFE for concurrent use. Install before the hook is wired.
+func (p *Permission) SetPaneCaptureForTest(fn func(target string, lines int) (string, error)) {
+	p.paneCapture = fn
 }
 
 // Store returns the backing *Store so tests and cross-package

--- a/internal/daemon/permission/reply.go
+++ b/internal/daemon/permission/reply.go
@@ -11,6 +11,12 @@ import (
 	"github.com/leonletto/thrum/internal/types"
 )
 
+// paneRecheckLines controls how much pane tail we capture for the
+// pre-send recheck. Matches paneBottomMatchLines (detect.go) so the
+// recheck sees the same scoped window as the scheduler's original
+// detection — no new spurious matches or misses from a wider capture.
+const paneRecheckLines = paneBottomMatchLines
+
 // approveReplyRe and denyReplyRe match a full supervisor reply body
 // (post ToLower + TrimSpace). Anchoring matters: a body like "why
 // not?" must NOT dispatch approve just because it contains "y".
@@ -108,6 +114,9 @@ func (p *Permission) TryResolve(ctx context.Context, evt types.MessageCreateEven
 				return // not ours
 			}
 		}
+		if !p.paneStillMatches("approve", row) {
+			return
+		}
 		if err := p.sendKeystroke(row.TmuxTarget, row.ApproveKey); err != nil {
 			// Row is already gone. No retry possible by design; log
 			// loudly so the operator can intervene by hand.
@@ -158,6 +167,9 @@ func (p *Permission) TryResolve(ctx context.Context, evt types.MessageCreateEven
 		}
 		if row == nil {
 			return // lost the race — peer already dispatched
+		}
+		if !p.paneStillMatches("deny", row) {
+			return
 		}
 		if err := p.sendKeystroke(row.TmuxTarget, row.DenyKey); err != nil {
 			slog.Error("[permission] deny keystroke failed AFTER atomic claim",
@@ -222,6 +234,68 @@ func (p *Permission) claimNudgeViaThreadID(ctx context.Context, replyTo string) 
 		return nil, nil
 	}
 	return p.store.DeleteAndReturnPendingNudge(ctx, threadID)
+}
+
+// paneStillMatches captures the pane tail at dispatch time and checks
+// that DetectPaneState still reports the same pattern the nudge row
+// was opened against. Returns true when the pane still shows the
+// prompt (safe to fire the keystroke) and false when the pane has
+// moved on (skip the keystroke to avoid stray input — e.g. an extra
+// "1" that lands in the post-approval turn).
+//
+// Capture failures are treated as "no longer matches" (fail-closed):
+// better to skip a keystroke on a transient tmux hiccup than fire
+// blind into a pane we cannot observe. thrum-rfy3 field repro: two
+// supervisors approving near-simultaneously produced an extra
+// keystroke on a couple of occasions; this recheck closes the
+// remaining race windows the atomic claim cannot on its own.
+//
+// Recovery on skip: when paneStillMatches returns false the row is
+// already atomically deleted by the caller. The prompt is NOT
+// orphaned — if it is still present on the next tmux silence cycle,
+// HandleCheckPane → OnDetection → firstDetect re-fires with a fresh
+// row. Delay is bounded by the check-pane cadence (seconds), not
+// forever, so a transient capture hiccup is self-healing.
+//
+// Logging is emitted here so the caller can stay log-free: Info for
+// the expected pane-moved-on case (the operator already approved in
+// the pane, or recovery fired concurrently — nothing to do), Warn
+// for the capture-error and malformed-pattern cases so operators see
+// the recovery-pending state.
+//
+// `op` is the caller's operation ("approve"/"deny") and is threaded
+// into the log attrs so a grep over logs can distinguish which reply
+// path was short-circuited.
+func (p *Permission) paneStillMatches(op string, row *NudgeRow) bool {
+	capture := p.paneCapture
+	if capture == nil {
+		capture = tmux.CapturePane
+	}
+	content, err := capture(row.TmuxTarget, paneRecheckLines)
+	if err != nil {
+		slog.Warn("[permission] "+op+" skipped — pane recheck capture failed (will re-fire on next check-pane cycle if prompt persists)",
+			"target", row.TmuxTarget, "message_id", row.MessageID, "err", err)
+		return false
+	}
+	runtime, _, ok := strings.Cut(row.PatternKey, ".")
+	if !ok || runtime == "" {
+		// Malformed PatternKey shouldn't reach here (set by
+		// firstDetect from a validated Pattern), but fail-closed if
+		// it somehow does: without a runtime we cannot re-detect.
+		slog.Warn("[permission] "+op+" skipped — malformed pattern key",
+			"target", row.TmuxTarget, "pattern_key", row.PatternKey,
+			"message_id", row.MessageID)
+		return false
+	}
+	detected := DetectPaneState(runtime, content)
+	expected := "permission:" + row.PatternKey
+	if detected == expected {
+		return true
+	}
+	slog.Info("[permission] "+op+" skipped — pane no longer matches pattern",
+		"target", row.TmuxTarget, "pattern_key", row.PatternKey,
+		"detected", detected, "message_id", row.MessageID)
+	return false
 }
 
 // sendKeystroke dispatches a cached keystroke sequence to the tmux

--- a/internal/daemon/permission/reply_test.go
+++ b/internal/daemon/permission/reply_test.go
@@ -41,14 +41,28 @@ func (r *recordingSender) snapshot() []keystrokeCall {
 	return out
 }
 
+// defaultReplyTestPane returns a pane tail that DetectPaneState
+// recognizes as "permission:cursor.not_in_allowlist" — the pattern
+// seeded by seedPendingNudge. Reply-path tests share this fake so the
+// pre-send recheck in TryResolve (thrum-rfy3) sees a matching pane
+// and dispatches the keystroke. Tests that want to exercise the
+// recheck-skips-dispatch branch install their own paneCapture via
+// SetPaneCaptureForTest.
+const defaultReplyTestPane = "Not in allowlist: some-command\n"
+
 // newReplyTestPermission constructs a Permission with an in-memory
-// store and an injected keystroke sender. No real state.State is
-// needed — the reply path only touches the store and the sender.
+// store, an injected keystroke sender, and a pane capture stub that
+// returns content matching the seeded pattern. No real state.State is
+// needed — the reply path only touches the store, the sender, and
+// the pane recheck.
 func newReplyTestPermission(t *testing.T, sender *recordingSender) *Permission {
 	t.Helper()
 	db := openTestDB(t)
 	p := New(nil, db, "supervisor_thrum", "thrum", ".")
 	p.keystrokeSender = sender.fn()
+	p.SetPaneCaptureForTest(func(_ string, _ int) (string, error) {
+		return defaultReplyTestPane, nil
+	})
 	return p
 }
 
@@ -558,5 +572,90 @@ func TestTryResolve_DirectFallback_Regression(t *testing.T) {
 	calls := sender.snapshot()
 	if len(calls) != 1 || calls[0].key != "y" {
 		t.Errorf("direct reply to firstDetect still expected to dispatch, got %v", calls)
+	}
+}
+
+// TestTryResolve_ApproveSkipsKeystrokeWhenPaneMoved verifies that a
+// supervisor reply does NOT send the approve keystroke if the pane
+// has moved past the prompt between claim and dispatch. This is the
+// thrum-rfy3 defense-in-depth: the atomic DELETE...RETURNING still
+// happens (so reminders stop), but the keystroke is skipped so a
+// stray "1" cannot land in the agent's post-approval turn.
+func TestTryResolve_ApproveSkipsKeystrokeWhenPaneMoved(t *testing.T) {
+	sender := &recordingSender{}
+	p := newReplyTestPermission(t, sender)
+
+	const msgID = "msg_moved_pane"
+	seedPendingNudge(t, p, msgID, "y", "Escape")
+
+	// Pane has moved on — content no longer matches the seeded pattern.
+	p.SetPaneCaptureForTest(func(_ string, _ int) (string, error) {
+		return "$ ls\nfile1.go\nfile2.go\n", nil
+	})
+
+	p.TryResolve(context.Background(),
+		types.MessageCreateEvent{Body: types.MessageBody{Content: "y"}},
+		msgID)
+
+	if calls := sender.snapshot(); len(calls) != 0 {
+		t.Errorf("expected keystroke to be skipped when pane moved on, got %v", calls)
+	}
+	// Row was still claimed (atomic semantics preserved) so reminders
+	// stop firing — the pane moved on, so this is the correct end state.
+	if row, _ := p.store.LookupPendingNudgeByMessageID(context.Background(), msgID); row != nil {
+		t.Error("expected nudge row to be deleted by atomic claim even when pane recheck skipped dispatch")
+	}
+}
+
+// TestTryResolve_DenySkipsKeystrokeWhenPaneMoved verifies the deny
+// path also honours the pre-send pane recheck.
+func TestTryResolve_DenySkipsKeystrokeWhenPaneMoved(t *testing.T) {
+	sender := &recordingSender{}
+	p := newReplyTestPermission(t, sender)
+
+	const msgID = "msg_moved_pane_deny"
+	seedPendingNudge(t, p, msgID, "y", "Escape")
+
+	p.SetPaneCaptureForTest(func(_ string, _ int) (string, error) {
+		return "agent turn content; no prompt visible", nil
+	})
+
+	p.TryResolve(context.Background(),
+		types.MessageCreateEvent{Body: types.MessageBody{Content: "n"}},
+		msgID)
+
+	if calls := sender.snapshot(); len(calls) != 0 {
+		t.Errorf("expected deny keystroke to be skipped when pane moved on, got %v", calls)
+	}
+	// Row was claimed atomically (deny path matches approve semantics):
+	// reminders stop, pane-moved-on is the correct end state. See
+	// TestTryResolve_ApproveSkipsKeystrokeWhenPaneMoved for the sibling
+	// assertion on the approve path.
+	if row, _ := p.store.LookupPendingNudgeByMessageID(context.Background(), msgID); row != nil {
+		t.Error("expected nudge row to be deleted by atomic claim even when deny recheck skipped dispatch")
+	}
+}
+
+// TestTryResolve_ApproveSkipsKeystrokeOnCaptureError verifies the
+// fail-closed stance: if we cannot observe the pane, we don't guess —
+// skip the keystroke rather than fire blind. Logged as WARN for
+// operator visibility.
+func TestTryResolve_ApproveSkipsKeystrokeOnCaptureError(t *testing.T) {
+	sender := &recordingSender{}
+	p := newReplyTestPermission(t, sender)
+
+	const msgID = "msg_capture_fail"
+	seedPendingNudge(t, p, msgID, "y", "Escape")
+
+	p.SetPaneCaptureForTest(func(_ string, _ int) (string, error) {
+		return "", errors.New("tmux capture-pane failed: no such session")
+	})
+
+	p.TryResolve(context.Background(),
+		types.MessageCreateEvent{Body: types.MessageBody{Content: "y"}},
+		msgID)
+
+	if calls := sender.snapshot(); len(calls) != 0 {
+		t.Errorf("expected keystroke to be skipped on capture error (fail-closed), got %v", calls)
 	}
 }

--- a/internal/daemon/permission/scheduler.go
+++ b/internal/daemon/permission/scheduler.go
@@ -192,17 +192,26 @@ func (p *Permission) firstDetect(
 
 	body := FormatNudge(row, paneTail, runtime, p.projectName, now)
 	var firstMsgID string
-	for i, to := range supers {
-		// First-detect messages have no thread yet; threadID="" lets
-		// the projector store NULL so the message_id itself becomes
-		// the thread root that fireReminder will reference.
-		msgID, err := p.SendSupervisorMessage(ctx, to, body, "")
+	for _, to := range supers {
+		// The first successful send carries threadID="" so the
+		// projector stores NULL and its own message_id becomes the
+		// thread root — the nudge row PK. Every subsequent
+		// supervisor send must carry threadID=firstMsgID so
+		// TryResolve's thread_id fallback can walk a reply aimed at
+		// supers[1+].msg_id back to the nudge row. Matches
+		// fireReminder's pattern (row.MessageID as threadID).
+		//
+		// thrum-rfy3: before this linkage, a Telegram reply to
+		// supers[1]'s nudge silently no-op'd because the direct
+		// lookup missed the PK and the thread_id fallback had no
+		// thread to walk.
+		msgID, err := p.SendSupervisorMessage(ctx, to, body, firstMsgID)
 		if err != nil {
 			slog.Error("[permission] send nudge failed", "to", to, "err", err)
 			continue
 		}
 		slog.Info("[permission] nudge sent", "to", to, "msg_id", msgID, "session", session)
-		if i == 0 {
+		if firstMsgID == "" {
 			firstMsgID = msgID
 		}
 	}

--- a/internal/daemon/permission/scheduler_test.go
+++ b/internal/daemon/permission/scheduler_test.go
@@ -152,6 +152,100 @@ func TestScheduler_FirstDetect(t *testing.T) {
 	}
 }
 
+// TestScheduler_FirstDetect_MultiSupervisor_SecondReplyResolves — when
+// firstDetect fans the nudge out to multiple supervisors (e.g.
+// coordinator + @user:leon-letto on Telegram), a supervisor other than
+// supers[0] must still be able to approve. The nudge row PK is
+// supers[0].msg_id by construction, so supers[1+]'s nudges must carry
+// thread_id = supers[0].msg_id so TryResolve's thread-ID fallback can
+// walk a reply-to-supers[1] back to the row.
+//
+// Regression: before the fix, firstDetect passed threadID="" for every
+// supervisor in the loop. Replies aimed at supers[1].msg_id missed
+// both the direct lookup (wrong PK) and the thread_id fallback (no
+// thread linkage), so the pane stayed blocked. See thrum-rfy3 for the
+// 2026-04-21 field repro.
+func TestScheduler_FirstDetect_MultiSupervisor_SecondReplyResolves(t *testing.T) {
+	p, _ := newSchedulerFixture(t)
+	ctx := context.Background()
+
+	// Register a second coordinator so ResolveSupervisors (default role
+	// "coordinator") returns two recipients and firstDetect's loop
+	// iterates twice.
+	if err := p.state.WriteEvent(ctx, types.AgentRegisterEvent{
+		Type:      "agent.register",
+		Timestamp: "2026-04-14T00:00:02Z",
+		AgentID:   "coordinator_secondary",
+		Kind:      "agent",
+		Role:      "coordinator",
+		Module:    "test",
+	}); err != nil {
+		t.Fatalf("register second coordinator: %v", err)
+	}
+	if err := p.state.WriteEvent(ctx, types.AgentSessionStartEvent{
+		Type:      "agent.session.start",
+		Timestamp: "2026-04-14T00:00:03Z",
+		SessionID: "ses_coordinator_secondary",
+		AgentID:   "coordinator_secondary",
+	}); err != nil {
+		t.Fatalf("start second coordinator session: %v", err)
+	}
+
+	sender := &recordingSender{}
+	p.keystrokeSender = sender.fn()
+	// Pre-send pane recheck needs to see a matching pane or it
+	// skips the dispatch; stub a cursor-pattern tail so the focus
+	// stays on the multi-supervisor threading invariant.
+	p.SetPaneCaptureForTest(func(_ string, _ int) (string, error) {
+		return "Not in allowlist: test\n", nil
+	})
+
+	if err := p.OnDetection(ctx, "cursor-test", "cursor", "cursor-test:0.0",
+		"researcher_cursor", testPattern(), "pane A"); err != nil {
+		t.Fatalf("first detect: %v", err)
+	}
+
+	row, err := p.store.LookupPendingNudgeBySession(ctx, "cursor-test")
+	if err != nil || row == nil {
+		t.Fatalf("expected nudge row, err=%v row=%v", err, row)
+	}
+
+	// The nudge row PK must be supers[0].msg_id. The second supervisor
+	// message must exist AND carry thread_id = row.MessageID so the
+	// reply-path thread fallback can resolve replies aimed at it.
+	var secondMsgID, secondThreadID string
+	if err := p.state.RawDB().QueryRow(`
+		SELECT message_id, COALESCE(thread_id, '') FROM messages
+		WHERE agent_id = 'supervisor_thrum' AND message_id != ?
+		ORDER BY created_at ASC LIMIT 1`, row.MessageID).Scan(&secondMsgID, &secondThreadID); err != nil {
+		t.Fatalf("expected a second supervisor message in messages table: %v", err)
+	}
+	if secondThreadID != row.MessageID {
+		t.Fatalf("second supervisor msg thread_id = %q, want %q (nudge row PK) — without this linkage, replies to the second supervisor's nudge cannot resolve the nudge row",
+			secondThreadID, row.MessageID)
+	}
+
+	// Simulate a supervisor (e.g. Leon via Telegram) replying "y" to
+	// the SECOND supervisor's nudge.
+	p.TryResolve(ctx,
+		types.MessageCreateEvent{Body: types.MessageBody{Content: "y"}},
+		secondMsgID)
+
+	calls := sender.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 keystroke dispatch via thread fallback, got %d: %v",
+			len(calls), calls)
+	}
+	if calls[0].key != "y" {
+		t.Errorf("expected key 'y', got %q", calls[0].key)
+	}
+
+	gone, _ := p.store.LookupPendingNudgeByMessageID(ctx, row.MessageID)
+	if gone != nil {
+		t.Error("nudge row should be deleted after approve via fallback")
+	}
+}
+
 func TestScheduler_NoReminderBeforeCadence(t *testing.T) {
 	p, clock := newSchedulerFixture(t)
 	ctx := context.Background()

--- a/internal/daemon/permission/send.go
+++ b/internal/daemon/permission/send.go
@@ -18,11 +18,14 @@ import (
 //
 // ThreadID, when non-empty, is written into the message's thread_id column
 // so that all reminder messages share the same thread as the firstDetect
-// message. The firstDetect call passes "" (no thread yet); subsequent
-// fireReminder calls pass the nudge row's MessageID (which is the
-// firstDetect message_id and therefore the thread root). TryResolve's
-// thread_id fallback relies on this linkage to resolve replies that
-// target a reminder message_id rather than the firstDetect message_id.
+// message. firstDetect passes "" for the FIRST supervisor (establishing
+// the thread root — its message_id becomes the nudge row PK) and passes
+// firstMsgID for every subsequent supervisor in the same fan-out.
+// fireReminder calls pass the nudge row's MessageID (= firstMsgID) as
+// threadID for every recipient. TryResolve's thread_id fallback relies
+// on this linkage to resolve replies that target any nudge message_id
+// other than the nudge row PK — i.e., a reminder or a non-first
+// supervisor's nudge (thrum-rfy3).
 //
 // Mirrors internal/daemon/rpc/queue_rpc.go:474 sendSystemMessage but
 // uses p.supervisorID (e.g. "supervisor_thrum") as the author instead

--- a/internal/daemon/rpc/message_test.go
+++ b/internal/daemon/rpc/message_test.go
@@ -2298,6 +2298,14 @@ func TestHandleSend_ReplyInterceptor(t *testing.T) {
 		sentKeys = append(sentKeys, sentKey{target, key})
 		return nil
 	})
+	// Pre-send pane recheck (thrum-rfy3): production defaults to
+	// tmux.CapturePane, which can't see a test's fake target. Stub
+	// with content that matches the seeded cursor pattern so the
+	// recheck lets the keystroke through — the invariant under test
+	// is routing+dispatch, not the recheck behavior itself.
+	p.SetPaneCaptureForTest(func(_ string, _ int) (string, error) {
+		return "Not in allowlist: some-command\n", nil
+	})
 
 	// Install the event-write hook in the same shape as production
 	// runDaemon. Sync variant here for simple test assertions — the


### PR DESCRIPTION
## Summary

Two related fixes to the permission-nudge reply-dispatch path, surfaced by a 2026-04-21 field repro (perm-test pane stayed blocked after Leon replied "Y" via Telegram):

- **Multi-supervisor threading**: `firstDetect` now passes `firstMsgID` as `threadID` for every supervisor after the first successful send. Before, all supervisor nudges were sent with `threadID=""`, so only `supers[0]`'s msg_id became the nudge row PK. Replies targeting `supers[1+].msg_id` missed both the direct lookup and the thread-ID fallback and silently no-op'd. Mirrors `fireReminder`'s existing pattern.
- **Pre-send pane recheck**: `TryResolve` now captures the pane tail and re-verifies `DetectPaneState` still reports the same `PatternKey` before firing approve/deny keystrokes. Closes the "extra 1 sent / agent confused" symptom when two supervisors approve near-simultaneously — the atomic DELETE…RETURNING prevents double-claim but couldn't prevent stray keystrokes landing in the post-approval turn. Fail-closed on capture error; self-heals via the next check-pane cadence.

Bead: **thrum-rfy3**

## Changes

- `internal/daemon/permission/scheduler.go` — `firstDetect` threads supervisor nudges via `firstMsgID`
- `internal/daemon/permission/reply.go` — new `paneStillMatches(op, row)` helper called before both approve and deny keystroke dispatch; consolidated skip-path logging (Info for pane-moved-on, Warn for capture-error / malformed-pattern)
- `internal/daemon/permission/permission.go` — `paneCapture` seam on `*Permission` + `SetPaneCaptureForTest` helper
- `internal/daemon/permission/send.go` — godoc updated for the new threading contract
- `internal/daemon/permission/nudge.go` — format comment on `NudgeRow.PatternKey` (dot is load-bearing; `strings.Cut` consumer in reply.go)
- `internal/daemon/permission/reply_test.go` — 3 new tests (approve-pane-moved, deny-pane-moved with row-deletion assertion, approve-capture-error); existing helpers switched to `SetPaneCaptureForTest`
- `internal/daemon/permission/scheduler_test.go` — `TestScheduler_FirstDetect_MultiSupervisor_SecondReplyResolves` regression covering the thread_id invariant
- `internal/daemon/rpc/message_test.go` — cross-package test (`TestHandleSend_ReplyInterceptor`) wires a `SetPaneCaptureForTest` stub so the recheck lets the routing-under-test keystroke through

## Test plan

- [x] `go test ./internal/daemon/permission/ -race -count=1` — 4 new tests + all existing green
- [x] `go test ./internal/daemon/rpc/ -race -count=1` — cross-package integration test green
- [x] `go test ./internal/daemon/... -count=1` — all 14 daemon packages green
- [x] Dual-review addressed: IMPORTANT 1–3, MINOR 4+6 (MINOR 5 skipped per reviewer discretion)
- [ ] Post-merge: `make install` + `thrum daemon restart` at Leon's discretion to deploy to shared `~/.local/bin/thrum`

## Reviewer notes

- Recheck intentionally happens **after** atomic claim: pane-moved-on means the row deletion (reminders stop) is the correct end-state, so no need to roll back the claim. Documented in `paneStillMatches` godoc.
- Runtime parsed from `PatternKey` via `strings.Cut` — no schema change. MINOR #4 comment guards against future dot-less keys silently failing closed.
- Fail-closed on capture error is by design: skip + Warn log + rely on next check-pane cadence to re-fire if the prompt persists. Recovery path documented inline.