### PR TITLE
fix(mcp): port wait_for_message waiter to polling (thrum-ufv5.9)

### DIFF
--- a/cmd/thrum/mcp.go
+++ b/cmd/thrum/mcp.go
@@ -101,15 +101,10 @@ func runMCPServe(agentID string) error {
 		cancel()
 	}()
 
-	// Initialize WebSocket waiter for wait_for_message (best-effort)
-	wsPort := cli.ReadWebSocketPort(repoPath)
-	if wsPort > 0 {
-		wsURL := fmt.Sprintf("ws://localhost:%d/ws", wsPort)
-		if initErr := server.InitWaiter(ctx, wsURL); initErr != nil {
-			// Log but continue — MCP server works without waiter
-			fmt.Fprintf(os.Stderr, "Warning: WebSocket waiter not available (wait_for_message will fail): %v\n", initErr)
-		}
-	}
+	// Attach polling waiter for wait_for_message. The waiter shares the
+	// same message.list path as the CLI `thrum wait` command and requires
+	// no WebSocket connection.
+	server.InitWaiter(ctx)
 
 	// Run MCP server (blocks on stdio until client disconnects)
 	return server.Run(ctx)

--- a/internal/mcp/integration_test.go
+++ b/internal/mcp/integration_test.go
@@ -165,6 +165,20 @@ func (td *testDaemon) createIdentity(t *testing.T, filename, role, module string
 	}
 }
 
+// useIdentity points the test process at this daemon's repo and selects
+// the given identity file. Tests that run in a shell with THRUM_HOME /
+// THRUM_NAME / THRUM_ROLE / THRUM_MODULE set (e.g. inside a Thrum
+// worktree) would otherwise resolve identities from the wrong place.
+func (td *testDaemon) useIdentity(t *testing.T, name string) {
+	t.Helper()
+	t.Setenv("THRUM_HOME", td.repoPath)
+	t.Setenv("THRUM_NAME", name)
+	t.Setenv("THRUM_AGENT_ID", "")
+	t.Setenv("THRUM_ROLE", "")
+	t.Setenv("THRUM_MODULE", "")
+	t.Setenv("THRUM_DISPLAY", "")
+}
+
 // newClient creates a daemon RPC client.
 func (td *testDaemon) newClient() (*cli.Client, error) {
 	return cli.NewClient(td.socketPath)
@@ -501,21 +515,23 @@ func TestMCPServerStartupFailsWithoutDaemon(t *testing.T) {
 	// The error should be something like "dial unix ... no such file or directory"
 }
 
-// TestWaitForMessageTimeout verifies timeout behavior when no messages arrive.
+// TestWaitForMessageTimeout verifies timeout behavior when no messages
+// arrive during the wait window. Uses the polling waiter against a real
+// daemon with no sender.
 func TestWaitForMessageTimeout(t *testing.T) {
-	t.Skip("TODO: Implement after WebSocket server is added to testDaemon")
-
 	td := newTestDaemon(t)
 	defer td.stop()
 
 	td.createIdentity(t, "waiter", "test-waiter", "mcp")
 	td.start(t)
+	td.registerAndStartSession(t, "test-waiter", "mcp", "waiter")
 
-	t.Setenv("THRUM_NAME", "waiter")
+	td.useIdentity(t, "waiter")
 	mcpServer, err := NewServer(td.repoPath)
 	if err != nil {
 		t.Fatalf("NewServer failed: %v", err)
 	}
+	mcpServer.InitWaiter(context.Background())
 
 	ctx := context.Background()
 	start := time.Now()
@@ -533,16 +549,16 @@ func TestWaitForMessageTimeout(t *testing.T) {
 		t.Errorf("expected status 'timeout', got %q", output.Status)
 	}
 
-	// Should take approximately 2 seconds
-	if elapsed < 1900*time.Millisecond || elapsed > 2500*time.Millisecond {
+	// Should take approximately 2 seconds; allow slack for CI scheduler noise.
+	if elapsed < 1800*time.Millisecond || elapsed > 3*time.Second {
 		t.Errorf("expected ~2s timeout, took %v", elapsed)
 	}
 }
 
-// TestWaitForMessageReceivesMessage verifies message reception via WebSocket.
+// TestWaitForMessageReceivesMessage verifies that a message sent after the
+// wait begins wakes the polling waiter and is returned via the
+// wait_for_message MCP tool.
 func TestWaitForMessageReceivesMessage(t *testing.T) {
-	t.Skip("TODO: Implement after WebSocket server is added to testDaemon")
-
 	td := newTestDaemon(t)
 	defer td.stop()
 
@@ -550,15 +566,18 @@ func TestWaitForMessageReceivesMessage(t *testing.T) {
 	td.createIdentity(t, "waiter", "test-waiter", "mcp")
 
 	td.start(t)
+	td.registerAndStartSession(t, "test-sender", "mcp", "sender")
+	td.registerAndStartSession(t, "test-waiter", "mcp", "waiter")
 
 	ctx := context.Background()
 
-	// Start wait_for_message in a goroutine
-	t.Setenv("THRUM_NAME", "waiter")
+	// Build the waiter-side MCP server.
+	td.useIdentity(t, "waiter")
 	mcpWaiter, err := NewServer(td.repoPath)
 	if err != nil {
 		t.Fatalf("NewServer for waiter failed: %v", err)
 	}
+	mcpWaiter.InitWaiter(context.Background())
 
 	type waitResult struct {
 		output WaitForMessageOutput
@@ -573,11 +592,11 @@ func TestWaitForMessageReceivesMessage(t *testing.T) {
 		resultCh <- waitResult{output, err}
 	}()
 
-	// Give waiter time to connect to WebSocket (intentional - ensuring operation is in-flight)
-	time.Sleep(500 * time.Millisecond)
+	// Give the poller time to enter its loop and establish `after`.
+	time.Sleep(600 * time.Millisecond)
 
-	// Send a message to waiter
-	t.Setenv("THRUM_NAME", "sender")
+	// Send a message from sender to waiter (by agent name).
+	td.useIdentity(t, "sender")
 	mcpSender, err := NewServer(td.repoPath)
 	if err != nil {
 		t.Fatalf("NewServer for sender failed: %v", err)
@@ -591,11 +610,13 @@ func TestWaitForMessageReceivesMessage(t *testing.T) {
 		t.Fatalf("handleSendMessage failed: %v", err)
 	}
 
-	// Wait for result with timeout
+	// Wait for the background goroutine to pick the message up. Allow
+	// generous slack: poll interval is 500ms and the sender fires after
+	// the waiter's `after` timestamp.
 	select {
 	case result := <-resultCh:
 		if result.err != nil {
-			t.Fatalf("waitForMessageHandler failed: %v", result.err)
+			t.Fatalf("handleWaitForMessage failed: %v", result.err)
 		}
 		if result.output.Status != "message_received" {
 			t.Errorf("expected status 'message_received', got %q", result.output.Status)
@@ -609,8 +630,28 @@ func TestWaitForMessageReceivesMessage(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("wait_for_message did not return within 5 seconds")
 	}
+}
 
-	// Should return in < 2 seconds (we waited 500ms + send time)
+// TestWaitForMessageNotInitializedErrors verifies that calling
+// wait_for_message before InitWaiter returns the expected error.
+func TestWaitForMessageNotInitializedErrors(t *testing.T) {
+	td := newTestDaemon(t)
+	defer td.stop()
+	td.createIdentity(t, "lonely", "test-lonely", "mcp")
+	td.start(t)
+
+	td.useIdentity(t, "lonely")
+	mcpServer, err := NewServer(td.repoPath)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	_, _, err = mcpServer.handleWaitForMessage(context.Background(), nil, WaitForMessageInput{
+		Timeout: 1,
+	})
+	if err == nil {
+		t.Fatal("expected error when waiter is not initialized, got nil")
+	}
 }
 
 // waitForSocketReady waits for a Unix socket to become available and accept connections, with timeout.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -81,21 +81,15 @@ func NewServer(repoPath string, opts ...Option) (*Server, error) {
 	return s, nil
 }
 
-// SetWaiter sets the WebSocket waiter for real-time message notifications.
+// SetWaiter sets the waiter used by the wait_for_message tool.
 func (s *Server) SetWaiter(w *Waiter) {
 	s.waiter = w
 }
 
-// InitWaiter initializes the WebSocket waiter for real-time notifications.
-// WsURL should be like "ws://localhost:9999/ws". If the WebSocket is not
-// available, the MCP server still works — wait_for_message returns an error.
-func (s *Server) InitWaiter(ctx context.Context, wsURL string) error {
-	w, err := NewWaiter(ctx, s.socketPath, s.agentID, s.agentRole, wsURL)
-	if err != nil {
-		return err
-	}
-	s.waiter = w
-	return nil
+// InitWaiter attaches a polling Waiter for the wait_for_message tool.
+// The returned Waiter lives for the duration of ctx.
+func (s *Server) InitWaiter(ctx context.Context) {
+	s.waiter = NewWaiter(ctx, s.socketPath, s.agentID, s.agentRole)
 }
 
 // Run starts the MCP server on stdin/stdout. It blocks until the client

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -135,7 +135,7 @@ func (s *Server) handleWaitForMessage(
 	input WaitForMessageInput,
 ) (*gomcp.CallToolResult, WaitForMessageOutput, error) {
 	if s.waiter == nil {
-		return nil, WaitForMessageOutput{}, fmt.Errorf("wait_for_message requires WebSocket connection to daemon; waiter not initialized")
+		return nil, WaitForMessageOutput{}, fmt.Errorf("wait_for_message requires the polling waiter; call Server.InitWaiter first")
 	}
 
 	result, err := s.waiter.WaitForMessage(ctx, input.Timeout)

--- a/internal/mcp/waiter.go
+++ b/internal/mcp/waiter.go
@@ -2,340 +2,65 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/url"
+	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
-
-	"github.com/gorilla/websocket"
 
 	"github.com/leonletto/thrum/internal/cli"
 	"github.com/leonletto/thrum/internal/daemon/rpc"
 )
 
 const (
-	maxQueueSize       = 1000
 	defaultWaitTimeout = 300 // seconds
 	maxWaitTimeout     = 600 // seconds
+	pollInterval       = 500 * time.Millisecond
 )
 
-// MessageNotification represents a notification received via WebSocket.
-type MessageNotification struct {
-	MessageID string `json:"message_id"`
-	Preview   string `json:"preview"`
-	AgentID   string `json:"agent_id"`
-	Timestamp string `json:"timestamp"`
-}
+// reconnectTimeout caps how long we'll retry connecting to the daemon
+// before giving up and returning a timeout result. Declared as a var so
+// tests can shrink it; production callers must not mutate at runtime.
+var reconnectTimeout = 60 * time.Second
 
-// Waiter manages the WebSocket connection to the daemon for real-time
-// message notifications. It powers the wait_for_message MCP tool.
+// Waiter polls the daemon inbox for messages addressed to this agent.
+// It powers the wait_for_message MCP tool. The implementation mirrors the
+// CLI `thrum wait` polling loop (internal/cli/wait.go): 500ms ticker,
+// reconnect-on-failure, first-unseen-message wins.
+//
+// There is intentionally no WebSocket subscription. The previous design
+// registered a "subscribe" RPC which was removed when CLI subscribe
+// commands were deleted; polling shares the same message.list path the
+// CLI already relies on.
 type Waiter struct {
-	wsConn     *websocket.Conn
-	socketPath string // for per-call RPC clients
-	agentID    string // composite agent ID for subscriptions
-	agentRole  string
-	nextID     atomic.Int64 // incrementing JSON-RPC request ID
+	socketPath string
+	agentID    string // composite agent ID used for caller_agent_id + for_agent
+	agentRole  string // agent role used for for_agent_role
 
-	queue    []MessageNotification
-	mu       sync.Mutex
-	waiterCh chan struct{} // closed when notification arrives
-	active   bool          // whether a wait is currently active
+	mu     sync.Mutex
+	active bool
 
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
-// NewWaiter creates a Waiter that connects to the daemon WebSocket.
-// AgentID is the composite agent ID (e.g., "agent:implementer:abc123") used
-// for subscription lookup. If empty, falls back to role-based identity.
-func NewWaiter(ctx context.Context, socketPath, agentID, agentRole, wsURL string) (*Waiter, error) {
-	wCtx, cancel := context.WithCancel(ctx)
-
-	u, err := url.Parse(wsURL)
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("parse WebSocket URL: %w", err)
-	}
-
-	dialer := &websocket.Dialer{
-		HandshakeTimeout: 10 * time.Second,
-	}
-	conn, _, err := dialer.DialContext(wCtx, u.String(), nil)
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("connect to daemon WebSocket at %s: %w", wsURL, err)
-	}
-
-	w := &Waiter{
-		wsConn:     conn,
+// NewWaiter creates a polling Waiter. It never opens a network connection
+// at construction time; connections are established lazily by WaitForMessage
+// and torn down when the call returns.
+func NewWaiter(parent context.Context, socketPath, agentID, agentRole string) *Waiter {
+	ctx, cancel := context.WithCancel(parent)
+	return &Waiter{
 		socketPath: socketPath,
 		agentID:    agentID,
 		agentRole:  agentRole,
-		queue:      make([]MessageNotification, 0),
-		ctx:        wCtx,
+		ctx:        ctx,
 		cancel:     cancel,
 	}
-
-	// Register, identify, and subscribe via WebSocket RPC
-	if err := w.setup(); err != nil {
-		_ = conn.Close()
-		cancel()
-		return nil, fmt.Errorf("WebSocket setup: %w", err)
-	}
-
-	// Start read loop
-	go w.readLoop()
-
-	return w, nil
 }
 
-// setup re-registers the agent and subscribes to role-based mentions over WebSocket.
-// The agent was already registered via CLI (thrum quickstart); this is a re-registration
-// so the MCP server shares the same identity and session. This is the normal workflow:
-// CLI registers first, then MCP server connects for real-time notifications.
-func (w *Waiter) setup() error {
-	// 1. Re-register agent (idempotent — returns existing info if already registered)
-	_, err := w.wsRPC("agent.register", map[string]any{
-		"role":        w.agentRole,
-		"module":      "mcp",
-		"re_register": true,
-	})
-	if err != nil {
-		return fmt.Errorf("agent.register: %w", err)
-	}
-
-	// 2. Subscribe to direct name/agent mentions and role mentions so the waiter
-	// wakes for the same mention patterns inbox polling can see.
-	for _, mentionTarget := range mentionSubscriptionTargets(w.agentID, w.agentRole) {
-		subParams := map[string]any{
-			"mention_role": mentionTarget,
-		}
-		if w.agentID != "" {
-			subParams["caller_agent_id"] = w.agentID
-		}
-		if _, err = w.wsRPC("subscribe", subParams); err != nil {
-			// Subscription may already exist from a previous MCP serve in the same
-			// daemon session — treat "already exists" as non-fatal.
-			if !isAlreadyExistsError(err) {
-				return fmt.Errorf("subscribe mention %q: %w", mentionTarget, err)
-			}
-		}
-	}
-
-	// 3. Subscribe to @everyone group scope so broadcasts wake the waiter.
-	everyoneParams := map[string]any{
-		"scope": map[string]any{
-			"type":  "group",
-			"value": "everyone",
-		},
-	}
-	if w.agentID != "" {
-		everyoneParams["caller_agent_id"] = w.agentID
-	}
-	_, err = w.wsRPC("subscribe", everyoneParams)
-	if err != nil {
-		if !isAlreadyExistsError(err) {
-			return fmt.Errorf("subscribe everyone: %w", err)
-		}
-	}
-
-	// 4. Subscribe to all groups that currently include this agent so
-	// group-addressed messages wake the listener just like inbox polling does.
-	if err := w.subscribeCurrentGroups(); err != nil {
-		return fmt.Errorf("subscribe current groups: %w", err)
-	}
-
-	return nil
-}
-
-// isAlreadyExistsError checks if an error indicates a duplicate subscription.
-func isAlreadyExistsError(err error) bool {
-	return err != nil && (err.Error() == "subscribe: subscription already exists" ||
-		err.Error() == "RPC error -32000: subscribe: subscription already exists")
-}
-
-func (w *Waiter) subscribeCurrentGroups() error {
-	if w.agentID == "" {
-		return nil
-	}
-
-	client, err := cli.NewClient(w.socketPath)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = client.Close() }()
-
-	groupList, err := cli.GroupList(client, cli.GroupListOptions{})
-	if err != nil {
-		return err
-	}
-
-	for _, group := range groupList.Groups {
-		members, err := cli.GroupMembers(client, cli.GroupMembersOptions{
-			Name:   group.Name,
-			Expand: true,
-		})
-		if err != nil {
-			return err
-		}
-		if !containsAgent(members.Expanded, w.agentID) {
-			continue
-		}
-
-		params := map[string]any{
-			"scope": map[string]any{
-				"type":  "group",
-				"value": group.Name,
-			},
-			"caller_agent_id": w.agentID,
-		}
-		if _, err := w.wsRPC("subscribe", params); err != nil && !isAlreadyExistsError(err) {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func containsAgent(agentIDs []string, target string) bool {
-	for _, agentID := range agentIDs {
-		if agentID == target {
-			return true
-		}
-	}
-	return false
-}
-
-func mentionSubscriptionTargets(agentID, agentRole string) []string {
-	seen := make(map[string]struct{}, 2)
-	targets := make([]string, 0, 2)
-	for _, target := range []string{agentID, agentRole} {
-		if target == "" {
-			continue
-		}
-		if _, ok := seen[target]; ok {
-			continue
-		}
-		seen[target] = struct{}{}
-		targets = append(targets, target)
-	}
-	return targets
-}
-
-// wsRPC sends a JSON-RPC request over WebSocket and reads the response.
-func (w *Waiter) wsRPC(method string, params any) (json.RawMessage, error) { //nolint:unparam // result kept for future use
-	id := w.nextID.Add(1)
-	req := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      id,
-		"method":  method,
-	}
-	if params != nil {
-		req["params"] = params
-	}
-
-	if err := w.wsConn.WriteJSON(req); err != nil {
-		return nil, fmt.Errorf("write: %w", err)
-	}
-
-	// Read response (may need to skip notifications)
-	for {
-		_, msg, err := w.wsConn.ReadMessage()
-		if err != nil {
-			return nil, fmt.Errorf("read: %w", err)
-		}
-
-		var resp struct {
-			JSONRPC string          `json:"jsonrpc"`
-			ID      any             `json:"id,omitempty"`
-			Method  string          `json:"method,omitempty"`
-			Result  json.RawMessage `json:"result,omitempty"`
-			Error   *struct {
-				Code    int    `json:"code"`
-				Message string `json:"message"`
-			} `json:"error,omitempty"`
-		}
-		if err := json.Unmarshal(msg, &resp); err != nil {
-			continue // skip unparseable messages
-		}
-
-		// If it's a notification (no id), skip it during setup
-		if resp.ID == nil && resp.Method != "" {
-			continue
-		}
-
-		if resp.Error != nil {
-			return nil, fmt.Errorf("RPC error %d: %s", resp.Error.Code, resp.Error.Message)
-		}
-
-		return resp.Result, nil
-	}
-}
-
-// readLoop reads WebSocket messages and routes notifications to the queue.
-func (w *Waiter) readLoop() {
-	defer func() {
-		// Unblock any active waiter on connection loss
-		w.mu.Lock()
-		if w.waiterCh != nil {
-			close(w.waiterCh)
-			w.waiterCh = nil
-		}
-		w.mu.Unlock()
-	}()
-
-	for {
-		select {
-		case <-w.ctx.Done():
-			return
-		default:
-		}
-
-		_, msg, err := w.wsConn.ReadMessage()
-		if err != nil {
-			return // connection closed — defer will unblock waiters
-		}
-
-		// Parse as JSON-RPC notification
-		var notif struct {
-			Method string          `json:"method,omitempty"`
-			Params json.RawMessage `json:"params,omitempty"`
-		}
-		if err := json.Unmarshal(msg, &notif); err != nil {
-			continue
-		}
-
-		if notif.Method != "notification.message" {
-			continue
-		}
-
-		// Parse notification params
-		var n MessageNotification
-		if err := json.Unmarshal(notif.Params, &n); err != nil {
-			continue
-		}
-
-		w.mu.Lock()
-		// Cap queue size
-		if len(w.queue) >= maxQueueSize {
-			w.queue = w.queue[1:] // drop oldest
-		}
-		w.queue = append(w.queue, n)
-
-		// Wake waiting goroutine
-		if w.waiterCh != nil {
-			close(w.waiterCh)
-			w.waiterCh = nil
-		}
-		w.mu.Unlock()
-	}
-}
-
-// WaitForMessage blocks until a message arrives or the timeout expires.
+// WaitForMessage blocks until a message addressed to this agent arrives
+// (by name, by role, or via @everyone broadcast) or the timeout expires.
+// Only one wait may be active per Waiter instance.
 func (w *Waiter) WaitForMessage(ctx context.Context, timeout int) (*WaitForMessageOutput, error) {
-	// Validate timeout
 	if timeout <= 0 {
 		timeout = defaultWaitTimeout
 	}
@@ -343,119 +68,189 @@ func (w *Waiter) WaitForMessage(ctx context.Context, timeout int) (*WaitForMessa
 		timeout = maxWaitTimeout
 	}
 
-	// Enforce single-waiter
 	w.mu.Lock()
 	if w.active {
 		w.mu.Unlock()
 		return nil, fmt.Errorf("another wait_for_message is already active; only one waiter per agent")
 	}
 	w.active = true
-
-	// Check queue first
-	if len(w.queue) > 0 {
-		n := w.queue[0]
-		w.queue = w.queue[1:]
-		w.active = false
-		w.mu.Unlock()
-
-		msg, err := w.fetchAndMark(n.MessageID)
-		if err != nil {
-			return &WaitForMessageOutput{
-				Status:        "message_received",
-				Message:       &MessageInfo{MessageID: n.MessageID, Content: n.Preview, Timestamp: n.Timestamp},
-				WaitedSeconds: 0,
-			}, nil
-		}
-		return &WaitForMessageOutput{
-			Status:        "message_received",
-			Message:       msg,
-			WaitedSeconds: 0,
-		}, nil
-	}
-
-	// Set up waiter channel
-	ch := make(chan struct{})
-	w.waiterCh = ch
 	w.mu.Unlock()
 
+	defer func() {
+		w.mu.Lock()
+		w.active = false
+		w.mu.Unlock()
+	}()
+
 	startTime := time.Now()
+	// Look back 1 second so a message sent at the same instant the wait
+	// starts still satisfies the created_after > threshold check. Mirrors
+	// the CLI `thrum wait` default (cmd/thrum/main.go:1354). Without the
+	// lookback, MCP clients that send-then-wait in tight succession would
+	// race the poller and silently miss wakes.
+	after := startTime.Add(-1 * time.Second).UTC()
+	seen := make(map[string]bool)
 
-	// Block until message, timeout, or context cancellation
-	timer := time.NewTimer(time.Duration(timeout) * time.Second)
-	defer timer.Stop()
+	timeoutTimer := time.NewTimer(time.Duration(timeout) * time.Second)
+	defer timeoutTimer.Stop()
 
-	select {
-	case <-ch:
-		w.mu.Lock()
-		w.active = false
-		if len(w.queue) == 0 {
-			w.mu.Unlock()
-			return &WaitForMessageOutput{
-				Status:        "timeout",
-				WaitedSeconds: int(time.Since(startTime).Seconds()),
-			}, nil
+	// pollTicker drives both the successful-poll cadence AND reconnect
+	// retry cadence — a daemon outage uses the same tick to attempt
+	// re-dial. Intentionally coupled: if pollInterval is ever split from
+	// the reconnect rate, introduce a dedicated retryTicker here.
+	pollTicker := time.NewTicker(pollInterval)
+	defer pollTicker.Stop()
+
+	var client *cli.Client
+	defer func() {
+		if client != nil {
+			_ = client.Close()
 		}
-		n := w.queue[0]
-		w.queue = w.queue[1:]
-		w.mu.Unlock()
+	}()
 
-		msg, err := w.fetchAndMark(n.MessageID)
-		if err != nil {
-			msg = &MessageInfo{MessageID: n.MessageID, Content: n.Preview, Timestamp: n.Timestamp}
-		}
-		return &WaitForMessageOutput{
-			Status:        "message_received",
-			Message:       msg,
-			WaitedSeconds: int(time.Since(startTime).Seconds()),
-		}, nil
-
-	case <-timer.C:
-		w.mu.Lock()
-		w.waiterCh = nil
-		w.active = false
-		w.mu.Unlock()
+	timeoutResult := func() *WaitForMessageOutput {
 		return &WaitForMessageOutput{
 			Status:        "timeout",
-			WaitedSeconds: timeout,
-		}, nil
+			WaitedSeconds: int(time.Since(startTime).Seconds()),
+		}
+	}
 
-	case <-ctx.Done():
-		w.mu.Lock()
-		w.waiterCh = nil
-		w.active = false
-		w.mu.Unlock()
-		return nil, ctx.Err()
+	// Initial connect is best-effort; retries happen on each poll tick.
+	if c, err := cli.NewClient(w.socketPath); err == nil {
+		client = c
+	}
+
+	// reconnectSince tracks when we first noticed the daemon was
+	// unreachable so we can cap reconnection attempts at reconnectTimeout.
+	var reconnectSince time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-w.ctx.Done():
+			return nil, w.ctx.Err()
+		case <-timeoutTimer.C:
+			return timeoutResult(), nil
+		case <-pollTicker.C:
+			// Ensure we have a live client; try to open one if not.
+			if client == nil {
+				c, err := cli.NewClient(w.socketPath)
+				if err != nil {
+					if reconnectSince.IsZero() {
+						reconnectSince = time.Now()
+					} else if time.Since(reconnectSince) > reconnectTimeout {
+						// Daemon has been unreachable for the full
+						// reconnect budget. Surface as a structured
+						// timeout rather than a tool error so MCP
+						// clients get a uniform "no message" shape.
+						slog.Warn("mcp.waiter daemon unreachable, returning timeout",
+							"budget", reconnectTimeout.String(),
+							"elapsed", time.Since(startTime).String())
+						return timeoutResult(), nil
+					}
+					continue
+				}
+				client = c
+				reconnectSince = time.Time{}
+			}
+
+			msg, err := w.pollOnce(client, after, seen)
+			if err != nil {
+				// RPC failure — likely daemon restart. Drop the client
+				// and try to re-open on the next tick.
+				_ = client.Close()
+				client = nil
+				if reconnectSince.IsZero() {
+					reconnectSince = time.Now()
+				}
+				continue
+			}
+			if msg != nil {
+				return &WaitForMessageOutput{
+					Status:        "message_received",
+					Message:       msg,
+					WaitedSeconds: int(time.Since(startTime).Seconds()),
+				}, nil
+			}
+		}
 	}
 }
 
-// fetchAndMark fetches the full message via RPC.
-func (w *Waiter) fetchAndMark(messageID string) (*MessageInfo, error) {
-	client, err := cli.NewClient(w.socketPath)
-	if err != nil {
+// pollOnce performs a single message.list RPC with the waiter's filter
+// criteria. Returns the first unseen message (oldest wins), or nil if no
+// new message was found. Caller is responsible for reconnecting if err is
+// non-nil.
+func (w *Waiter) pollOnce(client *cli.Client, after time.Time, seen map[string]bool) (*MessageInfo, error) {
+	params := map[string]any{
+		"page_size":     10,
+		"sort_by":       "created_at",
+		"sort_order":    "desc",
+		"created_after": after.UTC().Format(time.RFC3339Nano),
+		"exclude_self":  true,
+	}
+	if w.agentID != "" {
+		params["caller_agent_id"] = w.agentID
+		params["for_agent"] = w.agentID
+	}
+	if w.agentRole != "" {
+		params["for_agent_role"] = w.agentRole
+	}
+
+	var inbox cli.InboxResult
+	if err := client.Call("message.list", params, &inbox); err != nil {
 		return nil, err
 	}
-	defer func() { _ = client.Close() }()
 
+	// Inbox comes back newest-first; walk oldest-first so a backlog burst
+	// returns in chronological order across successive waits.
+	for i := len(inbox.Messages) - 1; i >= 0; i-- {
+		m := inbox.Messages[i]
+		if seen[m.MessageID] {
+			continue
+		}
+		seen[m.MessageID] = true
+
+		full, err := fetchMessageWithClient(client, m.MessageID)
+		if err != nil {
+			// Fall back to the list-row content if message.get fails —
+			// the waker message is still legitimate, the fetch was
+			// best-effort. The list-row RPC already succeeded, so any
+			// error here is transient; the outer loop's reconnect
+			// tracker intentionally does NOT advance on this path
+			// (we still return a wake to the caller).
+			return &MessageInfo{ //nolint:nilerr // deliberate: degrade to preview, caller gets the wake
+				MessageID: m.MessageID,
+				From:      m.AgentID,
+				Content:   m.Body.Content,
+				Timestamp: m.CreatedAt,
+			}, nil
+		}
+		return full, nil
+	}
+	return nil, nil
+}
+
+// fetchMessageWithClient retrieves the full message body via message.get
+// on the same daemon connection the poll used. Reusing the client keeps
+// error-classification consistent with the outer reconnect tracker.
+func fetchMessageWithClient(client *cli.Client, messageID string) (*MessageInfo, error) {
 	var getResp rpc.GetMessageResponse
 	if err := client.Call("message.get", rpc.GetMessageRequest{MessageID: messageID}, &getResp); err != nil {
 		return nil, err
 	}
 
-	msg := &MessageInfo{
+	return &MessageInfo{
 		MessageID: getResp.Message.MessageID,
 		From:      getResp.Message.Author.AgentID,
 		Content:   getResp.Message.Body.Content,
 		Timestamp: getResp.Message.CreatedAt,
-	}
-
-	return msg, nil
+	}, nil
 }
 
-// Close shuts down the Waiter.
+// Close signals the Waiter to stop any in-flight WaitForMessage call.
+// Safe to call multiple times.
 func (w *Waiter) Close() error {
 	w.cancel()
-	if w.wsConn != nil {
-		return w.wsConn.Close()
-	}
 	return nil
 }

--- a/internal/mcp/waiter_test.go
+++ b/internal/mcp/waiter_test.go
@@ -2,91 +2,68 @@ package mcp
 
 import (
 	"context"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 )
 
-func TestWaiterQueueDrain(t *testing.T) {
-	// Test that WaitForMessage returns immediately when queue has messages
-	w := &Waiter{
-		queue: []MessageNotification{
-			{MessageID: "msg-1", Preview: "Hello", Timestamp: "2026-01-01T00:00:00Z"},
-		},
-		socketPath: "/nonexistent/socket", // fetchAndMark will fail, falling back to preview
-		ctx:        context.Background(),
-	}
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-	defer w.cancel()
-
-	result, err := w.WaitForMessage(context.Background(), 5)
-	if err != nil {
-		t.Fatalf("WaitForMessage: %v", err)
-	}
-
-	if result.Status != "message_received" {
-		t.Errorf("expected status 'message_received', got %q", result.Status)
-	}
-	if result.Message == nil {
-		t.Fatal("expected message, got nil")
-	}
-	if result.Message.MessageID != "msg-1" {
-		t.Errorf("expected message_id 'msg-1', got %q", result.Message.MessageID)
-	}
-	if result.WaitedSeconds != 0 {
-		t.Errorf("expected 0 waited_seconds for queued message, got %d", result.WaitedSeconds)
-	}
-}
-
-func TestWaiterTimeout(t *testing.T) {
-	w := &Waiter{
-		queue:      []MessageNotification{},
-		socketPath: "/nonexistent/socket",
-	}
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-	defer w.cancel()
+// TestWaiterTimeoutWithNoDaemon verifies the polling waiter returns a
+// timeout result (not an error) when the daemon is unreachable for the
+// entire wait window.
+func TestWaiterTimeoutWithNoDaemon(t *testing.T) {
+	// Use a socket that doesn't exist; polling connect attempts will fail
+	// on every tick. With a 1-second overall timeout the reconnect budget
+	// (60s) is irrelevant — timeoutTimer fires first.
+	socket := filepath.Join(t.TempDir(), "missing.sock")
+	w := NewWaiter(context.Background(), socket, "waiter_x", "test-role")
+	defer w.Close()
 
 	start := time.Now()
 	result, err := w.WaitForMessage(context.Background(), 1)
 	elapsed := time.Since(start)
 
 	if err != nil {
-		t.Fatalf("WaitForMessage: %v", err)
+		t.Fatalf("WaitForMessage returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
 	}
 	if result.Status != "timeout" {
 		t.Errorf("expected status 'timeout', got %q", result.Status)
 	}
-	if elapsed < 900*time.Millisecond {
-		t.Errorf("expected ~1 second wait, got %v", elapsed)
+	if elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("expected ~1s elapsed, got %v", elapsed)
 	}
 }
 
+// TestWaiterContextCancellation verifies the waiter returns the context
+// error when its parent context is canceled mid-wait.
 func TestWaiterContextCancellation(t *testing.T) {
-	w := &Waiter{
-		queue:      []MessageNotification{},
-		socketPath: "/nonexistent/socket",
-	}
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-	defer w.cancel()
+	socket := filepath.Join(t.TempDir(), "missing.sock")
+	w := NewWaiter(context.Background(), socket, "waiter_x", "test-role")
+	defer w.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	_, err := w.WaitForMessage(ctx, 30)
 	if err == nil {
-		t.Fatal("expected context cancellation error")
+		t.Fatal("expected context cancellation error, got nil")
+	}
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
 	}
 }
 
+// TestWaiterSingleActive verifies the single-waiter constraint: a second
+// concurrent WaitForMessage must fail fast with a specific error.
 func TestWaiterSingleActive(t *testing.T) {
-	w := &Waiter{
-		queue:      []MessageNotification{},
-		socketPath: "/nonexistent/socket",
-	}
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-	defer w.cancel()
+	socket := filepath.Join(t.TempDir(), "missing.sock")
+	w := NewWaiter(context.Background(), socket, "waiter_x", "test-role")
+	defer w.Close()
 
-	// Start first wait in background
+	// Start first wait in the background.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -94,93 +71,81 @@ func TestWaiterSingleActive(t *testing.T) {
 		_, _ = w.WaitForMessage(context.Background(), 2)
 	}()
 
-	// Give goroutine time to start waiting (intentional - ensuring operation is in-flight)
+	// Give the goroutine a moment to reach the active gate.
 	time.Sleep(50 * time.Millisecond)
 
-	// Second wait should fail
+	// Second wait should fail immediately.
 	_, err := w.WaitForMessage(context.Background(), 1)
 	if err == nil {
-		t.Fatal("expected error for concurrent wait")
+		t.Fatal("expected error for concurrent wait, got nil")
 	}
-	if err.Error() != "another wait_for_message is already active; only one waiter per agent" {
+	want := "another wait_for_message is already active; only one waiter per agent"
+	if err.Error() != want {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	wg.Wait()
 }
 
-func TestWaiterChannelSignal(t *testing.T) {
-	w := &Waiter{
-		queue:      []MessageNotification{},
-		socketPath: "/nonexistent/socket",
+// TestWaiterReconnectBudgetExhaustionReturnsTimeout verifies that when the
+// daemon is unreachable for the full reconnect budget, WaitForMessage
+// returns a structured timeout result (not an error). This is the
+// documented behavior for MCP clients, so they get a uniform "no message"
+// shape whether the outage was brief or prolonged.
+func TestWaiterReconnectBudgetExhaustionReturnsTimeout(t *testing.T) {
+	// Shrink the reconnect budget so the test doesn't wait 60s.
+	prev := reconnectTimeout
+	reconnectTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { reconnectTimeout = prev })
+
+	socket := filepath.Join(t.TempDir(), "missing.sock")
+	w := NewWaiter(context.Background(), socket, "waiter_x", "test-role")
+	defer w.Close()
+
+	start := time.Now()
+	// Overall timeout is 10s, well above the shrunk reconnect budget; we
+	// expect the budget to fire first and convert to a timeout result.
+	result, err := w.WaitForMessage(context.Background(), 10)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected timeout result, got error: %v", err)
 	}
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-	defer w.cancel()
-
-	// Start wait in background
-	resultCh := make(chan *WaitForMessageOutput, 1)
-	go func() {
-		result, err := w.WaitForMessage(context.Background(), 10)
-		if err != nil {
-			return
-		}
-		resultCh <- result
-	}()
-
-	// Give goroutine time to start waiting (intentional - ensuring operation is in-flight)
-	time.Sleep(50 * time.Millisecond)
-
-	// Simulate notification arrival
-	w.mu.Lock()
-	w.queue = append(w.queue, MessageNotification{
-		MessageID: "msg-signal",
-		Preview:   "Signal test",
-		Timestamp: "2026-01-01T00:00:00Z",
-	})
-	if w.waiterCh != nil {
-		close(w.waiterCh)
-		w.waiterCh = nil
+	if result == nil || result.Status != "timeout" {
+		t.Fatalf("expected status 'timeout', got %+v", result)
 	}
-	w.mu.Unlock()
-
-	select {
-	case result := <-resultCh:
-		if result.Status != "message_received" {
-			t.Errorf("expected status 'message_received', got %q", result.Status)
-		}
-		if result.Message == nil || result.Message.MessageID != "msg-signal" {
-			t.Error("expected message with ID 'msg-signal'")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("WaitForMessage did not return after signal")
+	// Should return in budget + a couple of poll ticks; generous upper
+	// bound to tolerate CI scheduler noise.
+	if elapsed > 2*time.Second {
+		t.Errorf("expected reconnect-budget-exhaustion to return within ~1s, took %v", elapsed)
 	}
 }
 
-func TestWaiterQueueOverflow(t *testing.T) {
-	w := &Waiter{
-		queue: make([]MessageNotification, maxQueueSize),
-	}
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-	defer w.cancel()
+// TestWaiterCloseStopsInFlight verifies Close() unblocks an in-flight wait.
+func TestWaiterCloseStopsInFlight(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "missing.sock")
+	w := NewWaiter(context.Background(), socket, "waiter_x", "test-role")
 
-	// Fill to capacity
-	for i := range w.queue {
-		w.queue[i] = MessageNotification{MessageID: "old"}
-	}
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := w.WaitForMessage(context.Background(), 30)
+		errCh <- err
+	}()
 
-	// readLoop would add beyond capacity — simulate that
-	w.mu.Lock()
-	if len(w.queue) >= maxQueueSize {
-		w.queue = w.queue[1:]
-	}
-	w.queue = append(w.queue, MessageNotification{MessageID: "new"})
-	w.mu.Unlock()
+	// Allow the waiter to enter its polling loop.
+	time.Sleep(100 * time.Millisecond)
+	_ = w.Close()
 
-	if len(w.queue) != maxQueueSize {
-		t.Errorf("expected queue size %d, got %d", maxQueueSize, len(w.queue))
-	}
-	if w.queue[len(w.queue)-1].MessageID != "new" {
-		t.Error("expected newest message at end of queue")
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error after Close, got nil")
+		}
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForMessage did not return after Close")
 	}
 }
 
@@ -204,54 +169,6 @@ func TestDeriveAgentStatus(t *testing.T) {
 			got := deriveAgentStatus(tt.lastSeenAt, now)
 			if got != tt.expected {
 				t.Errorf("deriveAgentStatus(%q) = %q, want %q", tt.lastSeenAt, got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestMentionSubscriptionTargets(t *testing.T) {
-	tests := []struct {
-		name      string
-		agentID   string
-		agentRole string
-		want      []string
-	}{
-		{
-			name:      "named agent includes name and role",
-			agentID:   "coordinator_main",
-			agentRole: "coordinator",
-			want:      []string{"coordinator_main", "coordinator"},
-		},
-		{
-			name:      "unnamed agent includes id and role",
-			agentID:   "implementer_ABC123DEF4",
-			agentRole: "implementer",
-			want:      []string{"implementer_ABC123DEF4", "implementer"},
-		},
-		{
-			name:      "dedupes identical values",
-			agentID:   "reviewer",
-			agentRole: "reviewer",
-			want:      []string{"reviewer"},
-		},
-		{
-			name:      "role only",
-			agentID:   "",
-			agentRole: "tester",
-			want:      []string{"tester"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := mentionSubscriptionTargets(tt.agentID, tt.agentRole)
-			if len(got) != len(tt.want) {
-				t.Fatalf("got %v, want %v", got, tt.want)
-			}
-			for i := range tt.want {
-				if got[i] != tt.want[i] {
-					t.Fatalf("got %v, want %v", got, tt.want)
-				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes **thrum-ufv5.9**: MCP `wait_for_message` was silently broken because the waiter called a `subscribe` RPC that was deleted in the CLI-subscribe-removal refactor.

The WebSocket-based waiter at `internal/mcp/waiter.go:118,137,146` called `w.wsRPC("subscribe", ...)` for role-mention / `@everyone` / group subscriptions. Those RPC handlers were removed (see `cmd/thrum/main.go:5283,6195`). Result: `thrum mcp serve` booted with a loud warning and every MCP client that called `wait_for_message` silently got nothing.

This PR ports the waiter to the same polling pattern `thrum wait` uses (`internal/cli/wait.go`). No WebSocket connection is opened; the waiter shares `message.list` with the CLI.

## Changes

- **`internal/mcp/waiter.go`** — rewrite as polling Waiter (500ms ticker, `for_agent`/`for_agent_role`/`exclude_self` filter, seen-id dedup, auto-reconnect on daemon restart, 1-second lookback to avoid sender/waiter startup race). Dropped `MessageNotification`, `queue`, `readLoop`, `wsRPC`, `setup`, `subscribeCurrentGroups`, `isAlreadyExistsError`, `mentionSubscriptionTargets`.
- **`internal/mcp/server.go`** — `InitWaiter` no longer takes `wsURL` or returns an error (polling construction is infallible).
- **`internal/mcp/tools.go`** — updated the "not initialized" error string so it no longer references WebSocket.
- **`cmd/thrum/mcp.go`** — dropped `ReadWebSocketPort` lookup and the "waiter not available" warning.
- **`internal/mcp/waiter_test.go`** — replaced queue/WS tests with polling tests (timeout, context-cancel, single-active, close-unblocks, reconnect-budget exhaustion).
- **`internal/mcp/integration_test.go`** — un-skipped `TestWaitForMessageTimeout` / `TestWaitForMessageReceivesMessage` (previously `t.Skip("TODO: after WebSocket server")`), added `TestWaitForMessageNotInitializedErrors`, added `testDaemon.useIdentity` helper so the integration suite works when the host shell has `THRUM_HOME` / `THRUM_NAME` / `THRUM_AGENT_ID` / `THRUM_ROLE` / `THRUM_MODULE` / `THRUM_DISPLAY` env vars set.

## Design decisions

- **Polling over reviving subscribe RPC.** Subscribe was deliberately deleted; re-adding it would undo a refactor. Polling matches what `thrum wait` already does and reuses the same path MCP clients' `check_messages` tool uses.
- **`after = now - 1s` default.** Mirrors CLI wait (`cmd/thrum/main.go:1354`) — without it, a message sent at the same instant the wait starts gets filtered out by `created_after >` threshold.
- **Reconnect-budget exhaustion returns a structured timeout, not an error.** When the daemon is unreachable for the full 60s reconnect window, MCP clients see `{status: "timeout"}` instead of a tool error, with a `slog.Warn` for ops observability. Uniform "no message" shape is more useful to agent clients than a tool error.
- **`fetchMessageWithClient` threads the existing client.** Reuses the connection that just succeeded on `message.list` rather than opening a second socket per wake. Preview-fallback path explicitly documented as bypassing the reconnect tracker (list-row already succeeded → wake is legitimate).

## Test plan

- [x] `go test ./internal/mcp/` — 5 Waiter unit tests green (timeout-no-daemon, context-cancel, single-active, reconnect-budget-exhaustion, close-unblocks)
- [x] `go test -tags=integration ./internal/mcp/ -run TestWaitForMessage` — 3 integration tests green (timeout, end-to-end send+poll→receive, not-initialized error)
- [x] `go test ./internal/daemon/... ./cmd/thrum/` — full suite green, zero regressions
- [x] `golangci-lint run ./internal/mcp/` — 0 issues
- [x] Live repro: `./bin/thrum mcp serve </dev/null` boots silently — no `subscribe mention … RPC error -32601` warning (previously emitted on every boot)
- [ ] Merge