### PR TITLE
fix(tmux): launch identity invariants (x6e8.6 + x6e8.2)

### DIFF
--- a/cmd/thrum/main.go
+++ b/cmd/thrum/main.go
@@ -4379,6 +4379,7 @@ Examples:
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			noInit, _ := cmd.Flags().GetBool("no-init")
 			forceInit, _ := cmd.Flags().GetBool("force")
+			noAgentPID, _ := cmd.Flags().GetBool("no-agent-pid")
 
 			// Validate runtime if specified
 			if runtimeFlag != "" && !runtime.IsValidRuntime(runtimeFlag) {
@@ -4453,6 +4454,7 @@ Examples:
 				DryRun:       dryRun,
 				NoInit:       noInit,
 				Force:        forceInit,
+				NoAgentPID:   noAgentPID,
 			}
 
 			// In dry-run mode, we don't need a daemon connection
@@ -4619,6 +4621,13 @@ Examples:
 	cmd.Flags().Bool("no-init", false, "Skip runtime config generation, just register agent")
 	cmd.Flags().Bool("force", false, "Overwrite existing runtime config files")
 	cmd.Flags().String("preamble-file", "", "Custom preamble file to compose with default preamble")
+	// --no-agent-pid is intended for `thrum tmux create`'s inline
+	// quickstart. The inline caller is a short-lived subshell whose
+	// PID dies immediately; persisting it breaks `thrum tmux launch`'s
+	// G4 writer-liveness check. Direct shell use is allowed but
+	// unusual — first /thrum:prime from the runtime will reclaim the
+	// PID via guard.WritePID (thrum-x6e8.6).
+	cmd.Flags().Bool("no-agent-pid", false, "Persist agent_pid=0 instead of detecting the runtime ancestor (for inline tmux quickstart; defer PID claim to first /thrum:prime)")
 
 	return cmd
 }

--- a/cmd/thrum/main.go
+++ b/cmd/thrum/main.go
@@ -2219,6 +2219,10 @@ The agent identity is determined from:
 						fmt.Sprintf("%s_%s.json", flagRole, flagModule))
 					_ = os.Remove(legacyFile)
 				}
+				wtPath, err := worktree.NormalizeWorktreePath(flagRepo)
+				if err != nil {
+					return fmt.Errorf("normalize worktree path: %w", err)
+				}
 				identity := &config.IdentityFile{
 					Version: 3,
 					RepoID:  cli.GetRepoID(flagRepo),
@@ -2229,7 +2233,7 @@ The agent identity is determined from:
 						Module:  flagModule,
 						Display: cli.AutoDisplay(flagRole, flagModule),
 					},
-					Worktree: cli.GetWorktreeName(flagRepo),
+					Worktree: wtPath,
 					Branch:   cli.GetCurrentBranch(flagRepo),
 					Intent:   cli.DefaultIntent(flagRole, cli.GetRepoName(flagRepo)),
 				}
@@ -4510,6 +4514,10 @@ Examples:
 				idFile, _, loadErr := config.LoadIdentityWithPath(flagRepo)
 				if loadErr != nil || idFile == nil || idFile.Agent.Name != savedName {
 					// Create a new identity file: no existing file, or name mismatch
+					wtPath, wtErr := worktree.NormalizeWorktreePath(flagRepo)
+					if wtErr != nil {
+						return fmt.Errorf("normalize worktree path: %w", wtErr)
+					}
 					idFile = &config.IdentityFile{
 						Version: 4,
 						RepoID:  cli.GetRepoID(flagRepo),
@@ -4520,7 +4528,7 @@ Examples:
 							Module:  flagModule,
 							Display: cli.AutoDisplay(flagRole, flagModule),
 						},
-						Worktree: cli.GetWorktreeName(flagRepo),
+						Worktree: wtPath,
 						Branch:   cli.GetCurrentBranch(flagRepo),
 						Intent:   intent,
 					}

--- a/internal/cli/quickstart.go
+++ b/internal/cli/quickstart.go
@@ -43,6 +43,31 @@ type QuickstartOptions struct {
 	DryRun   bool   // Preview changes without writing
 	NoInit   bool   // Skip config file generation
 	Force    bool   // Overwrite existing files and force daemon re-registration (thrum-ufv5.6)
+
+	// NoAgentPID, when true, deregisters the caller's PID from the
+	// identity write — AgentPID is persisted as 0 instead of the
+	// detected runtime ancestor. Intended for the inline quickstart
+	// invoked by `thrum tmux create`: that invocation runs in a tmux
+	// pane's short-lived shell whose PID dies immediately after
+	// registration, so persisting it breaks `thrum tmux launch`'s G4
+	// writer-liveness check. Direct shell callers should not set this
+	// flag (thrum-x6e8.6).
+	NoAgentPID bool
+}
+
+// resolveQuickstartAgentPID returns the PID to persist in the identity
+// file's agent_pid field. When noAgentPID is set, returns 0 — the
+// caller is the tmux-create inline quickstart subshell whose PID will
+// not outlive this call; first-prime via guard.WritePID reclaims
+// ownership from the live runtime. Otherwise returns the detected
+// runtime ancestor (may still be 0 when no runtime is present, which
+// is the bare-shell case).
+func resolveQuickstartAgentPID(ctx context.Context, noAgentPID bool) int {
+	if noAgentPID {
+		return 0
+	}
+	pid, _ := process.FindClaudeAncestor(ctx)
+	return pid
 }
 
 // QuickstartResult contains the combined result of quickstart steps.
@@ -132,8 +157,10 @@ func Quickstart(client *Client, opts QuickstartOptions) (*QuickstartResult, erro
 
 	// Capture agent PID for identity resolution and conflict detection.
 	// Runtime/PreferredRuntime/branch/tmux fields are handled by
-	// RefreshLocalIdentity in Step 2.6 below.
-	agentPID, _ := process.FindClaudeAncestor(context.Background())
+	// RefreshLocalIdentity in Step 2.6 below. When NoAgentPID is set
+	// (the tmux-create inline path), we persist 0 — the first prime
+	// from the real runtime will reclaim via WritePID at main.go:4060.
+	agentPID := resolveQuickstartAgentPID(context.Background(), opts.NoAgentPID)
 
 	// Step 1: Register agent
 	//

--- a/internal/cli/quickstart_test.go
+++ b/internal/cli/quickstart_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -80,6 +81,37 @@ func TestExtractRoleFromID(t *testing.T) {
 				t.Errorf("extractRoleFromID(%q) = %q, want %q", tt.agentID, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveQuickstartAgentPID_NoAgentPID_ReturnsZero(t *testing.T) {
+	// When the tmux-create inline path sets noAgentPID=true, the
+	// caller's PID must NOT be persisted: the subshell exits and its
+	// PID dies, breaking HandleLaunch's G4 writer-liveness check.
+	got := resolveQuickstartAgentPID(context.Background(), true)
+	if got != 0 {
+		t.Errorf("expected 0 for noAgentPID=true, got %d", got)
+	}
+}
+
+func TestResolveQuickstartAgentPID_DefaultsToAncestorDetection(t *testing.T) {
+	// noAgentPID=false preserves the legacy behavior: detect a runtime
+	// ancestor and persist its PID. In test harness there's no runtime
+	// ancestor so the helper returns 0 — but it does so via the
+	// detection path, not via the early-return short-circuit.
+	got := resolveQuickstartAgentPID(context.Background(), false)
+	// Test harness has no runtime ancestor; just assert non-negative.
+	if got < 0 {
+		t.Errorf("expected non-negative PID, got %d", got)
+	}
+}
+
+func TestQuickstartOptions_NoAgentPIDFieldExists(t *testing.T) {
+	// Compile-time guarantee that the field exists with the right type;
+	// downstream callers (cmd/thrum/main.go) depend on this shape.
+	opts := QuickstartOptions{NoAgentPID: true}
+	if !opts.NoAgentPID {
+		t.Fatal("NoAgentPID field did not round-trip")
 	}
 }
 

--- a/internal/cli/worktree.go
+++ b/internal/cli/worktree.go
@@ -9,6 +9,6 @@ func EnsureWorktreeRedirects(worktreePath, mainRepo string) error {
 }
 
 // BuildQuickstartCmd delegates to worktree.BuildQuickstartCmd.
-func BuildQuickstartCmd(name, role, module, intent, runtime string) string {
-	return worktree.BuildQuickstartCmd(name, role, module, intent, runtime)
+func BuildQuickstartCmd(name, role, module, intent, runtime string, noAgentPID bool) string {
+	return worktree.BuildQuickstartCmd(name, role, module, intent, runtime, noAgentPID)
 }

--- a/internal/daemon/rpc/testhelpers_integration.go
+++ b/internal/daemon/rpc/testhelpers_integration.go
@@ -1,0 +1,20 @@
+//go:build integration
+
+package rpc
+
+// SetSessionCwdForTest wires a session→cwd mapping without going
+// through HandleCreate. Integration tests need this to exercise the
+// launch path without spinning up a full daemon bootstrap + git
+// worktree setup.
+//
+// Gated by the `integration` build tag so the production binary never
+// exposes this seam. Callers (tests/integration/*) must run with
+// `go test -tags=integration`.
+func SetSessionCwdForTest(h *TmuxHandler, sessionName, cwd string) {
+	h.sessionMu.Lock()
+	defer h.sessionMu.Unlock()
+	if h.sessionCwds == nil {
+		h.sessionCwds = make(map[string]string)
+	}
+	h.sessionCwds[sessionName] = cwd
+}

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -1266,6 +1266,19 @@ func (h *TmuxHandler) findIdentityForSession(ctx context.Context, sessionName st
 	return "", nil, ""
 }
 
+// SetSessionCwdForTest wires a session→cwd mapping without going
+// through HandleCreate. Integration tests need this to exercise the
+// launch path without spinning up a full daemon bootstrap + git
+// worktree setup. Not for production use.
+func SetSessionCwdForTest(h *TmuxHandler, sessionName, cwd string) {
+	h.sessionMu.Lock()
+	defer h.sessionMu.Unlock()
+	if h.sessionCwds == nil {
+		h.sessionCwds = make(map[string]string)
+	}
+	h.sessionCwds[sessionName] = cwd
+}
+
 // sessionCwd returns the cwd registered for a tmux session by
 // HandleCreate. False when the map has no entry or the entry is empty.
 // Shared between Pass 0 (writeTmuxByWorktreeCwd) and HandleLaunch's

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -292,12 +292,7 @@ func (h *TmuxHandler) HandleCreate(ctx context.Context, params json.RawMessage) 
 
 	// Run quickstart inside the pane for PID isolation
 	if !req.NoAgent {
-		// noAgentPID=true: the inline quickstart runs in the pane's
-		// shell which exits immediately after registration. Persisting
-		// its PID would trip HandleLaunch's G4 writer-liveness check on
-		// the subsequent launch. Prime from the real runtime claims the
-		// PID via guard.WritePID (thrum-x6e8.6).
-		quickstartCmd := worktree.BuildQuickstartCmd(req.AgentName, req.Role, req.Module, req.Intent, req.Runtime, true)
+		quickstartCmd := buildInlineQuickstartCmd(req)
 		target := name + ":0.0"
 		if err := ttmux.SendKeys(target, quickstartCmd); err != nil {
 			return nil, fmt.Errorf("send quickstart: %w", err)
@@ -1266,17 +1261,21 @@ func (h *TmuxHandler) findIdentityForSession(ctx context.Context, sessionName st
 	return "", nil, ""
 }
 
-// SetSessionCwdForTest wires a session→cwd mapping without going
-// through HandleCreate. Integration tests need this to exercise the
-// launch path without spinning up a full daemon bootstrap + git
-// worktree setup. Not for production use.
-func SetSessionCwdForTest(h *TmuxHandler, sessionName, cwd string) {
-	h.sessionMu.Lock()
-	defer h.sessionMu.Unlock()
-	if h.sessionCwds == nil {
-		h.sessionCwds = make(map[string]string)
-	}
-	h.sessionCwds[sessionName] = cwd
+// buildInlineQuickstartCmd returns the shell-safe quickstart command
+// HandleCreate sends into the tmux pane's shell. Factored so unit tests
+// can assert the exact emission (notably: --no-agent-pid must always be
+// present — the inline subshell exits immediately after registration,
+// persisting its PID breaks HandleLaunch's G4 writer-liveness check).
+//
+// The noAgentPID=true argument is fixed: HandleCreate has no legitimate
+// reason to emit an inline quickstart without the flag. If a future
+// caller needs the flag-less shape, route through a separate entry
+// point rather than parameterizing this one.
+func buildInlineQuickstartCmd(req TmuxCreateRequest) string {
+	return worktree.BuildQuickstartCmd(
+		req.AgentName, req.Role, req.Module, req.Intent, req.Runtime,
+		true, // --no-agent-pid: thrum-x6e8.6
+	)
 }
 
 // sessionCwd returns the cwd registered for a tmux session by

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -422,8 +422,22 @@ func (h *TmuxHandler) HandleLaunch(ctx context.Context, params json.RawMessage) 
 		}()
 	}
 
+	// Preamble: null the stored agent_pid if it belongs to an exited
+	// process. Without this, writeTmuxToIdentity's Pass 0 trips G4
+	// strict writer-liveness on the tmux-create inline-quickstart
+	// subshell PID and tmux_session never gets written. After the
+	// clear, Pass 0's subjectPID=0 skip applies and the write succeeds.
+	// First /thrum:prime then reclaims the PID via guard.WritePID at
+	// cmd/thrum/main.go:4060-4064 (thrum-x6e8.6).
+	h.clearStalePIDForLaunch(name)
+
 	// Write tmux_session and runtime to the agent's identity file
 	h.writeTmuxToIdentity(name, target, runtime)
+
+	// Part 3 regression guard: if tmux_session is still empty after the
+	// full write pass, emit an observable warn so future breakage of
+	// this invariant doesn't silently drift back in.
+	h.warnIfTmuxSessionEmpty(name)
 
 	// Enroll the session in the silence-hash poller. Runs detached from
 	// tmux's alert-silence hook (which is unreliable on detached
@@ -796,45 +810,26 @@ func (h *TmuxHandler) writeTmuxToIdentity(sessionName, target, runtime string) {
 // any fallback condition (no cwd mapping, empty identities dir, >1 file in
 // the dir, or G4 refusal) so the caller proceeds to Pass 1/2.
 func (h *TmuxHandler) writeTmuxByWorktreeCwd(sessionName, target, runtime string) bool {
-	h.sessionMu.RLock()
-	cwd, ok := h.sessionCwds[sessionName]
-	h.sessionMu.RUnlock()
-	if !ok || cwd == "" {
+	cwd, ok := h.sessionCwd(sessionName)
+	if !ok {
 		return false
 	}
 
-	idDir := filepath.Join(cwd, ".thrum", "identities")
-	entries, err := os.ReadDir(idDir)
-	if err != nil {
+	// Enumerate first (rather than calling soleIdentityFile directly) so
+	// the multi-file invariant-violation warn still fires on this path —
+	// HandleLaunch's preamble uses soleIdentityFile silently because
+	// ClearPIDIfDead is best-effort, but Pass 0 wants operator signal.
+	files := identityFilesInWorktree(cwd)
+	if len(files) == 0 {
 		return false
 	}
-
-	// Collect .json identity files in this worktree. EnforceOneIdentity
-	// (worktree package, invoked at HandleCreate quickstart path) guarantees
-	// a single identity per worktree. The slice below is cautious wording
-	// for an expected-to-be-one set.
-	var identityFiles []string
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-		identityFiles = append(identityFiles, filepath.Join(idDir, entry.Name()))
-	}
-	if len(identityFiles) == 0 {
-		return false
-	}
-	if len(identityFiles) > 1 {
-		// EnforceOneIdentity invariant violated. Fall back to Pass 1/2
-		// to avoid overwriting multiple files with the same session
-		// target. slog.Warn surfaces in structured daemon logs so
-		// operators can see the misconfiguration (log.Printf-level
-		// output is often filtered out by structured consumers).
+	if len(files) > 1 {
 		slog.Warn("tmux 51cg: multiple identity files in worktree — falling back to name/session match",
-			"worktree_cwd", cwd, "identity_files", identityFiles)
+			"worktree_cwd", cwd, "identity_files", files)
 		return false
 	}
 
-	path := identityFiles[0]
+	path := files[0]
 	data, err := os.ReadFile(path) // #nosec G304 -- path is .thrum/identities/<name>.json under a cwd we already trust
 	if err != nil {
 		return false
@@ -1269,6 +1264,104 @@ func (h *TmuxHandler) findIdentityForSession(ctx context.Context, sessionName st
 		}
 	}
 	return "", nil, ""
+}
+
+// sessionCwd returns the cwd registered for a tmux session by
+// HandleCreate. False when the map has no entry or the entry is empty.
+// Shared between Pass 0 (writeTmuxByWorktreeCwd) and HandleLaunch's
+// preamble so both operate on the same source of truth under the same
+// lock discipline.
+func (h *TmuxHandler) sessionCwd(sessionName string) (string, bool) {
+	h.sessionMu.RLock()
+	defer h.sessionMu.RUnlock()
+	cwd, ok := h.sessionCwds[sessionName]
+	if !ok || cwd == "" {
+		return "", false
+	}
+	return cwd, true
+}
+
+// identityFilesInWorktree enumerates .json identity files under
+// <cwd>/.thrum/identities/. Returns an empty slice for any read error or
+// empty directory; callers decide how to handle len==0 / len>1.
+func identityFilesInWorktree(cwd string) []string {
+	idDir := filepath.Join(cwd, ".thrum", "identities")
+	entries, err := os.ReadDir(idDir)
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		files = append(files, filepath.Join(idDir, entry.Name()))
+	}
+	return files
+}
+
+// soleIdentityFile returns the single .json identity file in
+// <cwd>/.thrum/identities/, or "" + false when zero or >1 files exist.
+// EnforceOneIdentity guarantees exactly one under normal operation;
+// callers that want an observable signal on the pathological >1 case
+// should enumerate directly via identityFilesInWorktree.
+func soleIdentityFile(cwd string) (string, bool) {
+	files := identityFilesInWorktree(cwd)
+	if len(files) != 1 {
+		return "", false
+	}
+	return files[0], true
+}
+
+// clearStalePIDForLaunch is HandleLaunch's preamble: if the session's
+// registered cwd maps to a single identity file whose stored agent_pid
+// belongs to an exited process, null it via guard.ClearPIDIfDead.
+// Best-effort — any enumeration or clear error is logged and swallowed;
+// the launch proceeds regardless.
+func (h *TmuxHandler) clearStalePIDForLaunch(sessionName string) {
+	cwd, ok := h.sessionCwd(sessionName)
+	if !ok {
+		return
+	}
+	idPath, ok := soleIdentityFile(cwd)
+	if !ok {
+		return
+	}
+	if _, err := guard.ClearPIDIfDead(idPath); err != nil {
+		slog.Warn("tmux.launch.clear-pid-failed",
+			slog.String("path", idPath),
+			slog.String("err", err.Error()),
+		)
+	}
+}
+
+// warnIfTmuxSessionEmpty inspects the session's identity file after
+// writeTmuxToIdentity has run and emits a regression warn when the
+// TmuxSession field is still empty. Surfaces Part 3 cascade regressions
+// that would otherwise be silent.
+func (h *TmuxHandler) warnIfTmuxSessionEmpty(sessionName string) {
+	cwd, ok := h.sessionCwd(sessionName)
+	if !ok {
+		return
+	}
+	idPath, ok := soleIdentityFile(cwd)
+	if !ok {
+		return
+	}
+	b, err := os.ReadFile(idPath) // #nosec G304 -- idPath is .thrum/identities/<name>.json under our own sessionCwd map
+	if err != nil {
+		return
+	}
+	var id config.IdentityFile
+	if err := json.Unmarshal(b, &id); err != nil {
+		return
+	}
+	if id.TmuxSession == "" {
+		slog.Warn("tmux.launch.tmux-session-still-empty",
+			slog.String("path", idPath),
+			slog.String("session", sessionName),
+		)
+	}
 }
 
 // clearTmuxFromIdentitiesInDir removes tmux_session and runtime from identity files

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -292,7 +292,12 @@ func (h *TmuxHandler) HandleCreate(ctx context.Context, params json.RawMessage) 
 
 	// Run quickstart inside the pane for PID isolation
 	if !req.NoAgent {
-		quickstartCmd := worktree.BuildQuickstartCmd(req.AgentName, req.Role, req.Module, req.Intent, req.Runtime)
+		// noAgentPID=true: the inline quickstart runs in the pane's
+		// shell which exits immediately after registration. Persisting
+		// its PID would trip HandleLaunch's G4 writer-liveness check on
+		// the subsequent launch. Prime from the real runtime claims the
+		// PID via guard.WritePID (thrum-x6e8.6).
+		quickstartCmd := worktree.BuildQuickstartCmd(req.AgentName, req.Role, req.Module, req.Intent, req.Runtime, true)
 		target := name + ":0.0"
 		if err := ttmux.SendKeys(target, quickstartCmd); err != nil {
 			return nil, fmt.Errorf("send quickstart: %w", err)

--- a/internal/daemon/rpc/tmux_launch_preamble_test.go
+++ b/internal/daemon/rpc/tmux_launch_preamble_test.go
@@ -1,0 +1,143 @@
+package rpc
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/leonletto/thrum/internal/config"
+)
+
+// TestClearStalePIDForLaunch_DeadPID_Clears covers the happy path for
+// HandleLaunch's preamble: an identity file with a dead stored PID
+// gets nulled so writeTmuxToIdentity's Pass 0 G4 skip applies.
+func TestClearStalePIDForLaunch_DeadPID_Clears(t *testing.T) {
+	cwd := t.TempDir()
+	idPath := writeTestIdentityFile(t, cwd, "impl_test", 2147483646, "") // guaranteed-dead PID
+
+	h := NewTmuxHandler(t.TempDir(), nil)
+	h.sessionMu.Lock()
+	h.sessionCwds = map[string]string{"test-session": cwd}
+	h.sessionMu.Unlock()
+
+	h.clearStalePIDForLaunch("test-session")
+
+	id := readTestIdentityFile(t, idPath)
+	if id.AgentPID != 0 {
+		t.Errorf("expected AgentPID cleared to 0, got %d", id.AgentPID)
+	}
+}
+
+// TestClearStalePIDForLaunch_LivePID_Noop: live PID must be preserved.
+// The dead-PID clear is specifically for the tmux-create subshell PID;
+// a legitimately-running runtime should not be molested.
+func TestClearStalePIDForLaunch_LivePID_Noop(t *testing.T) {
+	cwd := t.TempDir()
+	livePID := os.Getpid()
+	idPath := writeTestIdentityFile(t, cwd, "impl_test", livePID, "claude")
+
+	h := NewTmuxHandler(t.TempDir(), nil)
+	h.sessionMu.Lock()
+	h.sessionCwds = map[string]string{"test-session": cwd}
+	h.sessionMu.Unlock()
+
+	h.clearStalePIDForLaunch("test-session")
+
+	id := readTestIdentityFile(t, idPath)
+	if id.AgentPID != livePID {
+		t.Errorf("expected AgentPID unchanged (%d), got %d", livePID, id.AgentPID)
+	}
+}
+
+// TestClearStalePIDForLaunch_NoSession_Noop verifies the preamble is a
+// silent no-op when sessionCwds has no entry for this session (can
+// happen if HandleLaunch runs without a prior HandleCreate on the same
+// daemon instance).
+func TestClearStalePIDForLaunch_NoSession_Noop(t *testing.T) {
+	h := NewTmuxHandler(t.TempDir(), nil)
+	// Intentionally no sessionCwds entry
+	h.clearStalePIDForLaunch("test-session") // must not panic / error
+}
+
+// TestClearStalePIDForLaunch_MultipleIdentityFiles_Noop verifies the
+// preamble bails out silently when the worktree has >1 identity files
+// (EnforceOneIdentity invariant violated). Pass 0's multi-file warn in
+// writeTmuxByWorktreeCwd is the canonical operator signal for that
+// case; the preamble is intentionally a silent best-effort.
+func TestClearStalePIDForLaunch_MultipleIdentityFiles_Noop(t *testing.T) {
+	cwd := t.TempDir()
+	writeTestIdentityFile(t, cwd, "impl_a", 2147483646, "")
+	writeTestIdentityFile(t, cwd, "impl_b", 2147483646, "")
+
+	h := NewTmuxHandler(t.TempDir(), nil)
+	h.sessionMu.Lock()
+	h.sessionCwds = map[string]string{"test-session": cwd}
+	h.sessionMu.Unlock()
+
+	h.clearStalePIDForLaunch("test-session") // no panic, no error; neither file touched
+}
+
+// TestWarnIfTmuxSessionEmpty_Empty_Warns exercises the regression-guard
+// post-write inspection. We can't easily assert the slog.Warn fired
+// from a unit test, so this test verifies the code path runs without
+// panicking for the empty-tmux-session case. The visible signal is the
+// log emission in daemon stderr during a real HandleLaunch.
+func TestWarnIfTmuxSessionEmpty_Empty_Warns(t *testing.T) {
+	cwd := t.TempDir()
+	_ = writeTestIdentityFile(t, cwd, "impl_test", 0, "") // TmuxSession empty
+
+	h := NewTmuxHandler(t.TempDir(), nil)
+	h.sessionMu.Lock()
+	h.sessionCwds = map[string]string{"test-session": cwd}
+	h.sessionMu.Unlock()
+
+	h.warnIfTmuxSessionEmpty("test-session") // exercise path
+}
+
+// --- Test helpers ---
+
+// writeTestIdentityFile writes an identity file into cwd/.thrum/identities/<name>.json.
+func writeTestIdentityFile(t *testing.T, cwd, name string, pid int, tmuxSession string) string {
+	t.Helper()
+	idDir := filepath.Join(cwd, ".thrum", "identities")
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := config.IdentityFile{
+		Version: 4,
+		RepoID:  "test-repo",
+		Agent: config.AgentConfig{
+			Kind:    "agent",
+			Name:    name,
+			Role:    "implementer",
+			Module:  "test",
+			Display: name,
+		},
+		Worktree:    cwd,
+		AgentPID:    pid,
+		TmuxSession: tmuxSession,
+	}
+	b, err := json.MarshalIndent(id, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(idDir, name+".json")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func readTestIdentityFile(t *testing.T, path string) config.IdentityFile {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var id config.IdentityFile
+	if err := json.Unmarshal(b, &id); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return id
+}

--- a/internal/daemon/rpc/tmux_test.go
+++ b/internal/daemon/rpc/tmux_test.go
@@ -193,6 +193,56 @@ func TestTmuxHandler_HandleCreate_NoAgentSkipsValidation(t *testing.T) {
 	}
 }
 
+// TestBuildInlineQuickstartCmd_AlwaysEmitsNoAgentPID closes the
+// coverage gap between 'BuildQuickstartCmd flag wiring' (worktree pkg)
+// and 'HandleCreate actually invokes BuildQuickstartCmd with the flag
+// set'. A regression that silently dropped --no-agent-pid from
+// HandleCreate's call site would silently re-introduce thrum-x6e8.6.
+// This test pins the invariant at the HandleCreate-facing seam.
+func TestBuildInlineQuickstartCmd_AlwaysEmitsNoAgentPID(t *testing.T) {
+	req := TmuxCreateRequest{
+		AgentName: "impl_test",
+		Role:      "implementer",
+		Module:    "testing",
+		Intent:    "test intent",
+		Runtime:   "claude",
+	}
+	cmd := buildInlineQuickstartCmd(req)
+	if !strings.Contains(cmd, "--no-agent-pid") {
+		t.Errorf("HandleCreate's inline quickstart must emit --no-agent-pid, got: %s", cmd)
+	}
+	// Defense-in-depth: a no-op shape doesn't satisfy the assertion.
+	// The command must still carry the agent identity fields so the
+	// inline invocation actually registers something.
+	for _, need := range []string{"--name 'impl_test'", "--role 'implementer'", "--module 'testing'"} {
+		if !strings.Contains(cmd, need) {
+			t.Errorf("expected %q in quickstart command, got: %s", need, cmd)
+		}
+	}
+}
+
+// TestBuildInlineQuickstartCmd_EmptyOptionalFields verifies the command
+// degrades gracefully when intent/runtime are not supplied.
+// HandleCreate happily accepts empty optional fields, so the emission
+// must still carry --no-agent-pid and the required identity flags.
+func TestBuildInlineQuickstartCmd_EmptyOptionalFields(t *testing.T) {
+	req := TmuxCreateRequest{
+		AgentName: "impl_test",
+		Role:      "implementer",
+		Module:    "testing",
+	}
+	cmd := buildInlineQuickstartCmd(req)
+	if !strings.Contains(cmd, "--no-agent-pid") {
+		t.Errorf("expected --no-agent-pid even with empty intent/runtime, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "--intent") {
+		t.Errorf("expected no --intent when empty, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "--runtime") {
+		t.Errorf("expected no --runtime when empty, got: %s", cmd)
+	}
+}
+
 func TestTmuxHandler_HandleCreate_NotAWorktree(t *testing.T) {
 	handler := NewTmuxHandler(t.TempDir(), nil)
 	// cwd is a regular dir (no .git file), not a worktree

--- a/internal/identity/guard/clear_pid_if_dead.go
+++ b/internal/identity/guard/clear_pid_if_dead.go
@@ -1,0 +1,48 @@
+package guard
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/leonletto/thrum/internal/config"
+	"github.com/leonletto/thrum/internal/process"
+)
+
+// ClearPIDIfDead checks the stored agent_pid in an identity file for
+// liveness and clears it (via WritePID(path, 0)) when the process is not
+// running. Returns cleared=true when a clear happened, cleared=false when
+// the stored PID is already 0 or still alive.
+//
+// Defensive self-heal for identity files whose last-written PID belongs
+// to a process that has since exited — the canonical case is
+// `thrum tmux create`'s inline quickstart subshell whose PID is persisted
+// and then immediately exits when the subshell returns. Without this
+// clear, HandleLaunch's writeTmuxToIdentity Pass 0 trips the G4 strict
+// writer-liveness check on the dead PID and the tmux_session field never
+// gets written.
+//
+// On cleared=true the function emits a slog.Warn that surfaces as a hint
+// code via the slog-hint bridge.
+func ClearPIDIfDead(path string) (cleared bool, err error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- path is .thrum/identities/<name>.json, an internal identity file
+	if err != nil {
+		return false, fmt.Errorf("read identity %s: %w", path, err)
+	}
+	var id config.IdentityFile
+	if err := json.Unmarshal(b, &id); err != nil {
+		return false, fmt.Errorf("unmarshal identity %s: %w", path, err)
+	}
+	if id.AgentPID == 0 {
+		return false, nil
+	}
+	if process.IsRunning(id.AgentPID) {
+		return false, nil
+	}
+	if err := WritePID(path, 0); err != nil {
+		return false, fmt.Errorf("write cleared pid to %s: %w", path, err)
+	}
+	slog.Warn("tmux.launch.stale-pid-cleared", slog.String("path", path))
+	return true, nil
+}

--- a/internal/identity/guard/clear_pid_if_dead_test.go
+++ b/internal/identity/guard/clear_pid_if_dead_test.go
@@ -1,0 +1,63 @@
+package guard
+
+import (
+	"os"
+	"testing"
+)
+
+func TestClearPIDIfDead_LivePID_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	livePID := os.Getpid() // this test process is definitionally alive
+	path := writeIdentityFile(t, dir, "impl_foo", livePID, "claude")
+
+	cleared, err := ClearPIDIfDead(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleared {
+		t.Fatalf("expected cleared=false for live PID, got true")
+	}
+	id := loadIdentityForTest(t, path)
+	if id.AgentPID != livePID {
+		t.Fatalf("expected AgentPID unchanged (%d), got %d", livePID, id.AgentPID)
+	}
+}
+
+func TestClearPIDIfDead_DeadPID_Clears(t *testing.T) {
+	dir := t.TempDir()
+	// PID 2147483646 is well above any real PID and guaranteed dead on all
+	// supported platforms (Linux max pid_t is typically 99999; macOS is ~8M).
+	path := writeIdentityFile(t, dir, "impl_foo", 2147483646, "claude")
+
+	cleared, err := ClearPIDIfDead(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cleared {
+		t.Fatalf("expected cleared=true for dead PID, got false")
+	}
+	id := loadIdentityForTest(t, path)
+	if id.AgentPID != 0 {
+		t.Fatalf("expected AgentPID cleared to 0, got %d", id.AgentPID)
+	}
+}
+
+func TestClearPIDIfDead_ZeroPID_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := writeIdentityFile(t, dir, "impl_foo", 0, "claude")
+
+	cleared, err := ClearPIDIfDead(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleared {
+		t.Fatalf("expected cleared=false for already-zero PID, got true")
+	}
+}
+
+func TestClearPIDIfDead_MissingFile_Errors(t *testing.T) {
+	_, err := ClearPIDIfDead("/nonexistent/path/to/identity.json")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/identity/guard/guard.go
+++ b/internal/identity/guard/guard.go
@@ -217,6 +217,27 @@ func reconcileDrift(ctx context.Context, repoPath string, idFile *config.Identit
 		idFile.Branch = branch
 		changed = true
 	}
+	// thrum-x6e8.2: self-heal bare-name Worktree values. Pre-fix
+	// quickstart + worktree-create wrote filepath.Base(repoPath); three
+	// downstream consumers (main.go:8005 snapshot-save fallback,
+	// guard.CWDMatches at guard.go:102, context.WorktreePath at
+	// context.go:509) misbehave on the basename form. Since
+	// reconcileDrift is bound to the worktree at repoPath, we can
+	// derive the correct absolute path directly — no lookup, no
+	// shell-out. Best-effort: if repoPath is unstat-able, warn and
+	// preserve the stored value.
+	if idFile.Worktree != "" && !filepath.IsAbs(idFile.Worktree) {
+		if _, err := os.Stat(repoPath); err == nil {
+			idFile.Worktree = filepath.Clean(repoPath)
+			changed = true
+		} else if cc != nil && cc.warnLogger != nil {
+			cc.warnLogger.Warn("guard.reconcile.worktree-path-derive-failed",
+				slog.String("repo_path", repoPath),
+				slog.String("stored", idFile.Worktree),
+				slog.String("err", err.Error()),
+			)
+		}
+	}
 	if !changed {
 		return nil
 	}

--- a/internal/identity/guard/worktree_selfheal_test.go
+++ b/internal/identity/guard/worktree_selfheal_test.go
@@ -1,0 +1,134 @@
+package guard
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/leonletto/thrum/internal/config"
+)
+
+// writeIdentityFileWithWorktree is a focused helper for the worktree
+// self-heal tests. It writes an identity file with the given Worktree
+// field (the value under test) into the given identities dir.
+func writeIdentityFileWithWorktree(t *testing.T, idDir, name, worktree string) string {
+	t.Helper()
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := config.IdentityFile{
+		Version: 4,
+		RepoID:  "test-repo",
+		Agent: config.AgentConfig{
+			Kind:    "agent",
+			Name:    name,
+			Role:    "implementer",
+			Module:  "test",
+			Display: name,
+		},
+		Worktree: worktree,
+	}
+	b, err := json.MarshalIndent(id, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(idDir, name+".json")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestReconcileDrift_RewritesBareNameWorktree(t *testing.T) {
+	repoRoot := t.TempDir()
+	idDir := filepath.Join(repoRoot, ".thrum", "identities")
+	path := writeIdentityFileWithWorktree(t, idDir, "impl_foo", "thrum") // bare name
+
+	// Load the file as reconcileDrift would see it.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var idFile config.IdentityFile
+	if err := json.Unmarshal(b, &idFile); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	cc := &CheckContext{Ctx: context.Background()}
+	if err := reconcileDrift(context.Background(), repoRoot, &idFile, cc); err != nil {
+		t.Fatalf("reconcileDrift: %v", err)
+	}
+
+	// Read back to confirm the self-heal persisted to disk.
+	b2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	var after config.IdentityFile
+	if err := json.Unmarshal(b2, &after); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if !filepath.IsAbs(after.Worktree) {
+		t.Errorf("expected absolute Worktree, got %q", after.Worktree)
+	}
+	if after.Worktree != filepath.Clean(repoRoot) {
+		t.Errorf("expected Worktree=%q, got %q", filepath.Clean(repoRoot), after.Worktree)
+	}
+}
+
+func TestReconcileDrift_PreservesAbsoluteWorktree(t *testing.T) {
+	repoRoot := t.TempDir()
+	idDir := filepath.Join(repoRoot, ".thrum", "identities")
+	absPath := filepath.Clean(repoRoot)
+	_ = writeIdentityFileWithWorktree(t, idDir, "impl_foo", absPath)
+
+	idFile := config.IdentityFile{
+		Version:  4,
+		Worktree: absPath, // already absolute
+	}
+	cc := &CheckContext{Ctx: context.Background()}
+	// Nothing to do with an already-absolute Worktree — reconcileDrift
+	// may be a no-op or may persist other drift (runtime/branch). The
+	// important assertion is that Worktree isn't clobbered.
+	_ = reconcileDrift(context.Background(), repoRoot, &idFile, cc)
+
+	if idFile.Worktree != absPath {
+		t.Errorf("expected Worktree preserved as %q, got %q", absPath, idFile.Worktree)
+	}
+}
+
+func TestReconcileDrift_UnstatablePath_WarnsAndPreserves(t *testing.T) {
+	// Give reconcileDrift a repoPath that doesn't exist. Self-heal must
+	// NOT clobber the stored value; the helper logs and continues.
+	missing := filepath.Join(t.TempDir(), "does", "not", "exist")
+	idFile := config.IdentityFile{
+		Version:  4,
+		Worktree: "thrum", // bare name — invites rewrite
+	}
+	cc := &CheckContext{Ctx: context.Background()}
+
+	_ = reconcileDrift(context.Background(), missing, &idFile, cc)
+
+	// Even though the value is non-absolute, we must NOT rewrite to a
+	// non-existent path. Either it's still "thrum" or unchanged
+	// depending on whether other drift fired.
+	if filepath.IsAbs(idFile.Worktree) {
+		t.Errorf("expected Worktree preserved as-is, got absolute %q", idFile.Worktree)
+	}
+}
+
+func TestReconcileDrift_EmptyWorktree_NotChanged(t *testing.T) {
+	// Empty Worktree field must not trigger the self-heal (pre-quickstart
+	// state — caller hasn't told us the path yet).
+	repoRoot := t.TempDir()
+	idFile := config.IdentityFile{Version: 4, Worktree: ""}
+	cc := &CheckContext{Ctx: context.Background()}
+
+	_ = reconcileDrift(context.Background(), repoRoot, &idFile, cc)
+
+	if idFile.Worktree != "" {
+		t.Errorf("expected empty Worktree preserved, got %q", idFile.Worktree)
+	}
+}

--- a/internal/worktree/resolve.go
+++ b/internal/worktree/resolve.go
@@ -1,0 +1,35 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// NormalizeWorktreePath validates and canonicalizes an absolute worktree
+// path. Every caller writing identity.worktree must route through this
+// helper so the stored value is consistently absolute + cleaned — three
+// downstream consumers break silently on a bare-name form: snapshot-save
+// JSONL mtime fallback (cmd/thrum/main.go:8005), guard.CWDMatches
+// (internal/identity/guard/guard.go:102), and context.WorktreePath
+// (internal/context/context.go:509).
+//
+// Errors on: empty input, relative paths (caller must resolve), and
+// non-existent paths (caller must create the worktree before registering).
+// The resolver deliberately does NOT consult `git worktree list` — every
+// known caller already has the path (identity files live at
+// <worktree>/.thrum/identities/<name>.json), so name-to-path lookup is
+// not a real use case.
+func NormalizeWorktreePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("worktree path is empty")
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("worktree path must be absolute, got %q", path)
+	}
+	cleaned := filepath.Clean(path)
+	if _, err := os.Stat(cleaned); err != nil {
+		return "", fmt.Errorf("worktree path does not exist: %w", err)
+	}
+	return cleaned, nil
+}

--- a/internal/worktree/resolve.go
+++ b/internal/worktree/resolve.go
@@ -31,5 +31,12 @@ func NormalizeWorktreePath(path string) (string, error) {
 	if _, err := os.Stat(cleaned); err != nil {
 		return "", fmt.Errorf("worktree path does not exist: %w", err)
 	}
-	return cleaned, nil
+	// Resolve symlinks so downstream equality checks (e.g.
+	// guard.cwdMatches' filepath.EvalSymlinks pair) don't get tripped up
+	// by /tmp → /private/tmp on macOS or similar per-mount aliasing.
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree symlinks: %w", err)
+	}
+	return resolved, nil
 }

--- a/internal/worktree/resolve_test.go
+++ b/internal/worktree/resolve_test.go
@@ -1,0 +1,61 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeWorktreePath_AbsoluteExisting(t *testing.T) {
+	dir := t.TempDir()
+	got, err := NormalizeWorktreePath(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// macOS may return /private/tmp vs /tmp; accept either cleaned form.
+	want, _ := filepath.EvalSymlinks(dir)
+	if got != filepath.Clean(want) && got != filepath.Clean(dir) {
+		t.Fatalf("expected %q or %q, got %q", dir, want, got)
+	}
+}
+
+func TestNormalizeWorktreePath_Relative_ErrorsOut(t *testing.T) {
+	_, err := NormalizeWorktreePath("./relative/path")
+	if err == nil {
+		t.Fatal("expected error for relative input, got nil")
+	}
+}
+
+func TestNormalizeWorktreePath_BareName_ErrorsOut(t *testing.T) {
+	// This is the exact x6e8.2 symptom: GetWorktreeName returns the basename,
+	// which is not absolute. The helper must refuse.
+	_, err := NormalizeWorktreePath("thrum")
+	if err == nil {
+		t.Fatal("expected error for bare-name input, got nil")
+	}
+}
+
+func TestNormalizeWorktreePath_Empty_ErrorsOut(t *testing.T) {
+	_, err := NormalizeWorktreePath("")
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestNormalizeWorktreePath_NonExistent_ErrorsOut(t *testing.T) {
+	_, err := NormalizeWorktreePath("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("expected error for non-existent path, got nil")
+	}
+}
+
+func TestNormalizeWorktreePath_TrailingSlash_Cleaned(t *testing.T) {
+	dir := t.TempDir()
+	got, err := NormalizeWorktreePath(dir + string(os.PathSeparator))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != filepath.Clean(got) {
+		t.Fatalf("expected cleaned path, got %q", got)
+	}
+}

--- a/internal/worktree/resolve_test.go
+++ b/internal/worktree/resolve_test.go
@@ -12,10 +12,14 @@ func TestNormalizeWorktreePath_AbsoluteExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// macOS may return /private/tmp vs /tmp; accept either cleaned form.
-	want, _ := filepath.EvalSymlinks(dir)
-	if got != filepath.Clean(want) && got != filepath.Clean(dir) {
-		t.Fatalf("expected %q or %q, got %q", dir, want, got)
+	// The helper resolves symlinks, so the returned path must equal
+	// the symlink-resolved form of the input.
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected symlink-resolved %q, got %q", want, got)
 	}
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -326,7 +326,12 @@ func readAgentPID(path string) int {
 // for injection into a tmux pane. All values are single-quote wrapped.
 // Single quotes within values are escaped as '\” (end quote, escaped quote,
 // start quote). --force is always included for idempotent re-registration.
-func BuildQuickstartCmd(name, role, module, intent, runtime string) string {
+//
+// noAgentPID, when true, appends --no-agent-pid so the inline quickstart
+// persists agent_pid=0 instead of the caller's (short-lived subshell) PID.
+// Required for the tmux-create inline invocation — without it, HandleLaunch
+// trips G4 writer-liveness on a dead subshell PID (thrum-x6e8.6).
+func BuildQuickstartCmd(name, role, module, intent, runtime string, noAgentPID bool) string {
 	var parts []string
 	parts = append(parts, "thrum", "quickstart")
 	parts = append(parts, "--name", shellQuote(name))
@@ -341,6 +346,9 @@ func BuildQuickstartCmd(name, role, module, intent, runtime string) string {
 	}
 
 	parts = append(parts, "--force")
+	if noAgentPID {
+		parts = append(parts, "--no-agent-pid")
+	}
 
 	return strings.Join(parts, " ")
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -622,7 +622,7 @@ func TestEnforceOneIdentity_QuarantineSkipped(t *testing.T) {
 // --- BuildQuickstartCmd tests ---
 
 func TestBuildQuickstartCmd_Basic(t *testing.T) {
-	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "", "")
+	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "", "", false)
 	expected := "thrum quickstart --name 'impl_api' --role 'implementer' --module 'api' --force"
 	if cmd != expected {
 		t.Errorf("got %q, want %q", cmd, expected)
@@ -630,7 +630,7 @@ func TestBuildQuickstartCmd_Basic(t *testing.T) {
 }
 
 func TestBuildQuickstartCmd_WithIntent(t *testing.T) {
-	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "Build the API endpoints", "claude")
+	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "Build the API endpoints", "claude", false)
 	if !strings.Contains(cmd, "--intent 'Build the API endpoints'") {
 		t.Errorf("missing intent: %s", cmd)
 	}
@@ -640,18 +640,32 @@ func TestBuildQuickstartCmd_WithIntent(t *testing.T) {
 }
 
 func TestBuildQuickstartCmd_QuotesSpecialChars(t *testing.T) {
-	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "Build API; handle auth", "")
+	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "Build API; handle auth", "", false)
 	if !strings.Contains(cmd, "'Build API; handle auth'") {
 		t.Errorf("intent not safely quoted: %s", cmd)
 	}
 }
 
 func TestBuildQuickstartCmd_EscapesSingleQuoteInIntent(t *testing.T) {
-	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "Build API's auth", "")
+	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "Build API's auth", "", false)
 	if strings.Contains(cmd, "'Build API's auth'") {
 		t.Errorf("unescaped single quote would break shell: %s", cmd)
 	}
 	if !strings.Contains(cmd, `'Build API'\''s auth'`) {
 		t.Errorf("expected escaped single quote: %s", cmd)
+	}
+}
+
+func TestBuildQuickstartCmd_WithNoAgentPID_AppendsFlag(t *testing.T) {
+	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "", "", true)
+	if !strings.Contains(cmd, "--no-agent-pid") {
+		t.Errorf("expected --no-agent-pid flag when noAgentPID=true, got: %s", cmd)
+	}
+}
+
+func TestBuildQuickstartCmd_WithoutNoAgentPID_OmitsFlag(t *testing.T) {
+	cmd := BuildQuickstartCmd("impl_api", "implementer", "api", "", "", false)
+	if strings.Contains(cmd, "--no-agent-pid") {
+		t.Errorf("did not expect --no-agent-pid flag when noAgentPID=false, got: %s", cmd)
 	}
 }

--- a/tests/e2e/tmux-restart.spec.ts
+++ b/tests/e2e/tmux-restart.spec.ts
@@ -1,0 +1,21 @@
+import { test } from '@playwright/test';
+
+// Coordinator-initiated restart flow (release-test Step 10.1 equivalent).
+//
+// Gated as test.fixme until thrum-x6e8.5 (tmux-exec helper migration) lands:
+// on macOS, ~30-50 respawn-pane calls exhaust the pty pool and any test
+// using the current tmux-exec respawn pattern flakes. Un-fixme once the
+// helper migration is in place.
+//
+// Refs: thrum-nu16 (x6e8.6 + x6e8.2), thrum-x6e8.5.
+test.fixme('coordinator-initiated restart: create + launch + snapshot + restart', async () => {
+  // 1. thrum tmux create impl_x --name impl_x --role implementer --module testing --cwd <scratch-worktree>
+  // 2. thrum tmux launch impl_x
+  //    Assert identity: tmux_session populated, agent_pid == 0, worktree absolute.
+  // 3. Drive a /thrum:prime in the pane.
+  //    Assert identity: agent_pid == <runtime PID>.
+  // 4. thrum tmux snapshot save (no --jsonl flag)
+  //    Assert: succeeds (x6e8.2 symptom gone).
+  // 5. thrum tmux restart impl_x
+  //    Assert: new pane has the snapshot loaded, agent_pid reclaimed post-restart.
+});

--- a/tests/integration/tmux_launch_identity_test.go
+++ b/tests/integration/tmux_launch_identity_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/leonletto/thrum/internal/config"
 	"github.com/leonletto/thrum/internal/daemon/rpc"
@@ -93,8 +92,9 @@ func TestTmuxLaunch_IdentityInvariants_DeadPIDClearedAndSessionWritten(t *testin
 		t.Fatalf("HandleLaunch: %v", err)
 	}
 
-	// Let writes flush.
-	time.Sleep(200 * time.Millisecond)
+	// HandleLaunch writes synchronously (preamble → writeTmuxToIdentity
+	// → regression guard, all on the calling goroutine); assert
+	// immediately after return.
 
 	// Assert post-launch state.
 	postIdentity := readJSON[config.IdentityFile](t, idPath)

--- a/tests/integration/tmux_launch_identity_test.go
+++ b/tests/integration/tmux_launch_identity_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/leonletto/thrum/internal/config"
+	"github.com/leonletto/thrum/internal/daemon/rpc"
+	"github.com/leonletto/thrum/internal/identity/guard"
+	ttmux "github.com/leonletto/thrum/internal/tmux"
+)
+
+// TestTmuxLaunch_IdentityInvariants_DeadPIDClearedAndSessionWritten is
+// the L2 integration test for thrum-nu16 (x6e8.6 + x6e8.2). It drives
+// real tmux + a real TmuxHandler through the launch path and asserts
+// that:
+//
+//  1. Pre-launch, an identity file with a dead stored agent_pid
+//     simulates the x6e8.6 state (tmux-create inline-quickstart
+//     subshell PID that exited).
+//  2. The preamble (clearStalePIDForLaunch) nulls the dead PID.
+//  3. writeTmuxToIdentity's Pass 0 succeeds (G4 skips subjectPID=0).
+//  4. Post-launch, tmux_session is populated with target "<sess>:0.0"
+//     and agent_pid is 0 (awaiting first /thrum:prime).
+//  5. Worktree is an absolute path (no x6e8.2 regression).
+func TestTmuxLaunch_IdentityInvariants_DeadPIDClearedAndSessionWritten(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	// Clear ambient host env that would redirect identity loaders.
+	t.Setenv("THRUM_HOME", "")
+	t.Setenv("THRUM_NAME", "")
+	t.Setenv("THRUM_AGENT_ID", "")
+
+	cwd := t.TempDir() // scratch worktree (abs path by construction)
+	sessionName := "thrum-nu16-launch-test"
+
+	// Cleanup any stale session from a prior run + on exit.
+	_ = ttmux.KillSession(sessionName)
+	t.Cleanup(func() { _ = ttmux.KillSession(sessionName) })
+
+	// Pre-populate an identity file in the scratch worktree with a
+	// dead stored PID — simulates the state the tmux-create inline
+	// quickstart leaves behind when run in a pane subshell that
+	// subsequently exits.
+	deadPID := 2147483646 // guaranteed-dead
+	idDir := filepath.Join(cwd, ".thrum", "identities")
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		t.Fatalf("mkdir identities: %v", err)
+	}
+	idPath := filepath.Join(idDir, "impl_test.json")
+	preIdentity := config.IdentityFile{
+		Version: 4,
+		RepoID:  "test-repo",
+		Agent: config.AgentConfig{
+			Kind:    "agent",
+			Name:    "impl_test",
+			Role:    "implementer",
+			Module:  "testing",
+			Display: "impl_test",
+		},
+		Worktree: cwd,     // absolute — x6e8.2 shape
+		AgentPID: deadPID, // x6e8.6 shape
+	}
+	writeJSON(t, idPath, preIdentity)
+
+	// Create the tmux session the handler will operate on.
+	if err := ttmux.CreateSession(sessionName, cwd); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Build a TmuxHandler and register the session's cwd (HandleCreate
+	// normally populates this map; we bypass HandleCreate because it
+	// does much more than the launch invariant needs and would require
+	// a full daemon bootstrap).
+	handler := rpc.NewTmuxHandler(t.TempDir(), nil)
+	rpc.SetSessionCwdForTest(handler, sessionName, cwd)
+
+	// Invoke launch. Runtime "claude" matches the default; SendKeys
+	// will attempt to type "claude" into the pane, which is fine —
+	// the pane runs bash so it'll fail the command but the identity
+	// write completes before any launch-cmd failure would matter.
+	launchReq, _ := json.Marshal(map[string]any{"name": sessionName, "runtime": "claude"})
+	if _, err := handler.HandleLaunch(context.Background(), launchReq); err != nil {
+		t.Fatalf("HandleLaunch: %v", err)
+	}
+
+	// Let writes flush.
+	time.Sleep(200 * time.Millisecond)
+
+	// Assert post-launch state.
+	postIdentity := readJSON[config.IdentityFile](t, idPath)
+
+	if postIdentity.AgentPID != 0 {
+		t.Errorf("expected AgentPID cleared to 0 post-launch, got %d", postIdentity.AgentPID)
+	}
+	if postIdentity.TmuxSession == "" {
+		t.Errorf("expected TmuxSession populated post-launch, got empty (x6e8.6 regression)")
+	}
+	if !strings.HasPrefix(postIdentity.TmuxSession, sessionName) {
+		t.Errorf("expected TmuxSession to start with %q, got %q", sessionName, postIdentity.TmuxSession)
+	}
+	if !filepath.IsAbs(postIdentity.Worktree) {
+		t.Errorf("expected Worktree to stay absolute, got %q (x6e8.2 regression)", postIdentity.Worktree)
+	}
+	if postIdentity.Worktree != cwd {
+		t.Errorf("expected Worktree=%q, got %q", cwd, postIdentity.Worktree)
+	}
+}
+
+// TestTmuxLaunchPrime_PIDReclaim mirrors the prime-reclaim invariant
+// from spec Part 1D: after launch, a call to guard.WritePID with the
+// live runtime PID (as prime does at cmd/thrum/main.go:4060-4064)
+// writes the PID into the identity file, completing the handoff.
+func TestTmuxLaunchPrime_PIDReclaim(t *testing.T) {
+	cwd := t.TempDir()
+	idDir := filepath.Join(cwd, ".thrum", "identities")
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	idPath := filepath.Join(idDir, "impl_test.json")
+	writeJSON(t, idPath, config.IdentityFile{
+		Version: 4,
+		Agent: config.AgentConfig{
+			Kind: "agent", Name: "impl_test", Role: "implementer", Module: "testing",
+		},
+		Worktree: cwd,
+		AgentPID: 0, // post-launch state
+	})
+
+	// Simulate prime's WritePID call.
+	livePID := os.Getpid()
+	if err := guard.WritePID(idPath, livePID); err != nil {
+		t.Fatalf("WritePID: %v", err)
+	}
+
+	got := readJSON[config.IdentityFile](t, idPath)
+	if got.AgentPID != livePID {
+		t.Errorf("expected AgentPID=%d after prime reclaim, got %d", livePID, got.AgentPID)
+	}
+	if !filepath.IsAbs(got.Worktree) {
+		t.Errorf("expected Worktree absolute, got %q", got.Worktree)
+	}
+}
+
+// --- helpers ---
+
+func writeJSON[T any](t *testing.T, path string, v T) {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readJSON[T any](t *testing.T, path string) T {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var v T
+	if err := json.Unmarshal(b, &v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return v
+}


### PR DESCRIPTION
## Summary

Fixes two identity-bookkeeping bugs surfaced by v0.9.0 release-test Step 10:

- **thrum-x6e8.6**: `thrum tmux create + thrum tmux launch` now populates `identity.tmux_session`; daemon's `thrum tmux status` lists the session; `thrum tmux restart <session>` works. Root cause: `tmux create`'s inline quickstart subshell wrote its own PID; subshell exited; next launch tripped G4 writer-liveness on the dead PID.
- **thrum-x6e8.2**: `identity.worktree` is always an absolute path from every write site; existing bare-name identity files self-heal via `reconcileDrift`. Consumers that silently misbehaved on the bare-name form (snapshot-save JSONL fallback, `guard.CWDMatches`, `context.WorktreePath`) now get consistent inputs.

## Architecture

Two small helpers + surgical edits at existing write sites + one guard self-heal branch:

- **`guard.ClearPIDIfDead(path)`** — encapsulates the stale-PID clear pattern.
- **`worktree.NormalizeWorktreePath(path)`** — single choke-point for identity.worktree writes.
- **`--no-agent-pid` quickstart flag** — the tmux-create inline path now defers PID claim to the runtime's first `/thrum:prime` (existing `guard.WritePID` at `main.go:4060-4064`).
- **`HandleLaunch` preamble** — `clearStalePIDForLaunch(name)` before `writeTmuxToIdentity`; `warnIfTmuxSessionEmpty(name)` after as regression guard.
- **`reconcileDrift`** — extended with a bare-name → absolute self-heal branch; uses the existing `changed + SaveIdentityFile` path (no second save site).
- **`HandleStatus` cascade** — Part 3 verified: the daemon's tmux-status index reads `idFile.TmuxSession` as its source of truth (tmux.go:518-578), so once the preamble lets Pass 0 write the field, status listing cascades for free.

## Changes

- New: `internal/identity/guard/clear_pid_if_dead.go` + test
- New: `internal/worktree/resolve.go` + test
- New: `internal/daemon/rpc/tmux_launch_preamble_test.go`
- New: `internal/identity/guard/worktree_selfheal_test.go`
- New: `tests/integration/tmux_launch_identity_test.go` (L2 against real tmux)
- New: `tests/e2e/tmux-restart.spec.ts` (L4 `test.fixme` gated on x6e8.5)
- Modified: `internal/cli/quickstart.go` (NoAgentPID option + factored `resolveQuickstartAgentPID` helper)
- Modified: `internal/cli/quickstart_test.go` (3 tests for the new helper + field)
- Modified: `internal/worktree/worktree.go` (`BuildQuickstartCmd` gains `noAgentPID` param)
- Modified: `internal/worktree/worktree_test.go` (2 tests for the new flag)
- Modified: `internal/cli/worktree.go` (signature pass-through)
- Modified: `internal/daemon/rpc/tmux.go` (preamble + regression guard + sessionCwd/identityFilesInWorktree/soleIdentityFile helpers + SetSessionCwdForTest)
- Modified: `internal/identity/guard/guard.go` (Worktree self-heal branch in `reconcileDrift`)
- Modified: `cmd/thrum/main.go` (quickstart `--no-agent-pid` cobra flag; main.go:2232 + main.go:4521 use `NormalizeWorktreePath`)

## Test plan

- [x] L1 unit tests (24 new): ClearPIDIfDead (4), NormalizeWorktreePath (6), resolveQuickstartAgentPID (3), BuildQuickstartCmd flag (2), preamble+regression (5), reconcileDrift self-heal (4)
- [x] L2 integration (`tests/integration/tmux_launch_identity_test.go`, 2 tests) — drives real tmux + TmuxHandler through the launch path end-to-end
- [x] L4 e2e fixme placeholder (gated on thrum-x6e8.5)
- [x] `go test -race ./...` — full suite green
- [x] `make test && make lint` — test green, lint only pre-existing issues (none from new code)
- [ ] Manual x6e8.6 repro against test-env daemon (deferred; L2 integration exercises the same invariants)
- [ ] Manual x6e8.2 snapshot-save repro (deferred; self-heal test covers the consumer path)

Spec: `dev-docs/specs/2026-04-22-tmux-launch-identity-invariants-design.md`
Plan: `dev-docs/plans/2026-04-22-tmux-launch-identity-invariants-plan.md`

Closes thrum-x6e8.6 and thrum-x6e8.2 via thrum-nu16.