### PR TITLE
fix(tmux): HandleCreate blocks until inline quickstart writes identity (thrum-ns0b)

### DIFF
--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -292,79 +292,8 @@ func (h *TmuxHandler) HandleCreate(ctx context.Context, params json.RawMessage) 
 
 	// Run quickstart inside the pane for PID isolation
 	if !req.NoAgent {
-		quickstartCmd := buildInlineQuickstartCmd(req)
-		target := name + ":0.0"
-		if err := ttmux.SendKeys(target, quickstartCmd); err != nil {
-			return nil, fmt.Errorf("send quickstart: %w", err)
-		}
-		if err := ttmux.SendSpecialKey(target, "Enter"); err != nil {
-			return nil, fmt.Errorf("send enter: %w", err)
-		}
-		// Enforce single identity AFTER quickstart command is sent successfully.
-		// Quickstart runs asynchronously in the pane — this cleans pre-existing
-		// stale identities. The new identity will be written by quickstart.
-		//
-		// thrum-182j: mirror agent.go's keeper-list expansion so every
-		// agent registered against this worktree in session_refs
-		// survives enforcement. Without this, creating a tmux session
-		// for agent A in a worktree where agent B is already registered
-		// would quarantine agent B's identity file.
-		//
-		// Liveness gate (IsPIDAlive): refuse to quarantine a file whose
-		// AgentPID is currently running — kernel-verified backstop for
-		// a stale keeper list.
-		//
-		// AllowCrossWorktree is intentionally true here: HandleCreate
-		// legitimately operates on a target worktree (req.Cwd) that is
-		// NOT the caller's own cwd. The caller is typically a
-		// coordinator CLI instance creating a pane in a sibling
-		// worktree — the use case the static CWD-match guard is
-		// explicitly designed to allow via the override. The keeper-
-		// list expansion + liveness gate remain the active defenses
-		// on this path.
-		keepers := []string{req.AgentName}
-		if h.state != nil {
-			keepers = append(keepers, h.state.ListAgentsInWorktree(ctx, req.Cwd)...)
-		}
-		worktree.EnforceOneIdentityWith(req.Cwd, worktree.EnforceOpts{
-			IsPIDAlive:         func(pid int) bool { return process.IsRunning(pid) },
-			AllowCrossWorktree: true,
-		}, keepers...)
-
-		// Shell init (oh-my-zsh, etc.) can swallow the first command.
-		// Block until the identity file lands on disk: quickstart is
-		// inherently async (runs in the pane's shell), but the CLI
-		// caller typically chains `thrum tmux launch` back-to-back and
-		// HandleLaunch needs the identity file present to bind
-		// tmux_session. thrum-ns0b: was a goroutine pre-fix; the race
-		// silently left tmux_session null on the launch side.
-		idDir := filepath.Join(req.Cwd, ".thrum", "identities")
-		idPath := filepath.Join(idDir, req.AgentName+".json")
-		if resolved, err := filepath.EvalSymlinks(idDir); err == nil {
-			idPath = filepath.Join(resolved, req.AgentName+".json")
-		}
-		resend := func() error {
-			slog.Info("tmux.create.quickstart-resending",
-				slog.String("agent", req.AgentName), slog.String("session", name),
-			)
-			if err := ttmux.SendKeys(target, quickstartCmd); err != nil {
-				return err
-			}
-			return ttmux.SendSpecialKey(target, "Enter")
-		}
-		if err := waitForIdentityFile(idPath, 5*time.Second, 5*time.Second, resend); err != nil {
-			// Failure mode: quickstart never wrote the identity file
-			// even after a retry. Kill the tmux session so the caller
-			// doesn't see a half-initialized pane; return a structured
-			// error so the CLI caller can distinguish "create failed"
-			// from "create succeeded, launch failed."
-			slog.Warn("tmux.create.quickstart-timeout",
-				slog.String("agent", req.AgentName),
-				slog.String("session", name),
-				slog.String("err", err.Error()),
-			)
-			_ = ttmux.KillSession(name)
-			return nil, fmt.Errorf("tmux create: %w", err)
+		if err := h.runInlineQuickstart(ctx, req, name); err != nil {
+			return nil, err
 		}
 	} else {
 		// For bare sessions, still write tmux_session to any existing identity
@@ -1278,10 +1207,24 @@ func (h *TmuxHandler) findIdentityForSession(ctx context.Context, sessionName st
 // callers should not mutate at runtime.
 var identityPollInterval = 500 * time.Millisecond
 
+// tmux-side-effect seams. Package vars so unit tests can exercise
+// runInlineQuickstart end-to-end without a real tmux daemon. Tests
+// must restore the original values via t.Cleanup.
+var (
+	sendKeysFn       = ttmux.SendKeys
+	sendSpecialKeyFn = ttmux.SendSpecialKey
+	killSessionFn    = ttmux.KillSession
+)
+
 // waitForIdentityFile blocks until the identity file at idPath appears
 // on disk, or the combined initial+retry window expires. Between the
 // two windows, `resend` is invoked once — shell init (oh-my-zsh etc.)
 // can swallow the first send-keys, and a second attempt usually lands.
+//
+// The caller's ctx is honored: cancellation returns ctx.Err() even
+// while we would otherwise still be waiting. This matters for daemon
+// graceful-shutdown and client disconnects — without ctx-awareness a
+// client that drops mid-create would burn the full 10s budget.
 //
 // Returns nil on success. On resend-function failure the wrapped error
 // is returned immediately. On combined-timeout a descriptive error is
@@ -1293,35 +1236,128 @@ var identityPollInterval = 500 * time.Millisecond
 // files to bind tmux_session to (writeTmuxToIdentity fell through all
 // three passes). Running synchronously closes the race at the cost of
 // up to ~10s latency on HandleCreate when the shell is slow.
-func waitForIdentityFile(idPath string, initial, retry time.Duration, resend func() error) error {
-	if waitUntilExists(idPath, initial) {
+func waitForIdentityFile(ctx context.Context, idPath string, initial, retry time.Duration, resend func() error) error {
+	if ok, ctxErr := waitUntilExists(ctx, idPath, initial); ok {
 		return nil
+	} else if ctxErr != nil {
+		return ctxErr
 	}
 	if resend != nil {
 		if err := resend(); err != nil {
 			return fmt.Errorf("re-send quickstart after initial %s wait: %w", initial, err)
 		}
 	}
-	if waitUntilExists(idPath, retry) {
+	if ok, ctxErr := waitUntilExists(ctx, idPath, retry); ok {
 		return nil
+	} else if ctxErr != nil {
+		return ctxErr
 	}
 	return fmt.Errorf("quickstart did not write identity file %s within %s", idPath, initial+retry)
 }
 
 // waitUntilExists polls idPath every identityPollInterval up to the
-// given duration. Returns true as soon as os.Stat succeeds.
-func waitUntilExists(path string, within time.Duration) bool {
-	deadline := time.Now().Add(within)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(path); err == nil {
-			return true
-		}
-		time.Sleep(identityPollInterval)
+// given duration. Returns (true, nil) as soon as os.Stat succeeds,
+// (false, nil) on deadline, and (false, ctx.Err()) on context
+// cancellation. Never overshoots the caller's deadline by more than
+// the time of a single os.Stat call.
+func waitUntilExists(ctx context.Context, path string, within time.Duration) (bool, error) {
+	if _, err := os.Stat(path); err == nil {
+		return true, nil
 	}
-	// One final check at the deadline, in case the sleep-tick landed
-	// on us just as the file appeared.
-	_, err := os.Stat(path)
-	return err == nil
+	deadline := time.After(within)
+	ticker := time.NewTicker(identityPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-deadline:
+			return false, nil
+		case <-ticker.C:
+			if _, err := os.Stat(path); err == nil {
+				return true, nil
+			}
+		}
+	}
+}
+
+// runInlineQuickstart sends the inline thrum-quickstart command into
+// the pane's shell and blocks until the identity file is written (or
+// the combined 10s budget expires). Factored out of HandleCreate so
+// the synchronous-wait invariant can be asserted at the RPC boundary
+// in unit tests: a future refactor back to a background goroutine
+// would fail these tests even if the waitForIdentityFile helper stayed
+// in place.
+//
+// Failure modes:
+//   - sendKeysFn/sendSpecialKeyFn error → session untouched, error returned.
+//   - EnforceOneIdentityWith → best-effort cleanup, non-fatal.
+//   - Combined 10s budget exhausted → tmux session is killed so callers
+//     don't see a half-initialized pane, structured error returned.
+//
+// ctx is honored in the wait loop: daemon shutdown / client disconnect
+// mid-create returns ctx.Err() instead of burning the full budget.
+func (h *TmuxHandler) runInlineQuickstart(ctx context.Context, req TmuxCreateRequest, name string) error {
+	quickstartCmd := buildInlineQuickstartCmd(req)
+	target := name + ":0.0"
+	if err := sendKeysFn(target, quickstartCmd); err != nil {
+		return fmt.Errorf("send quickstart: %w", err)
+	}
+	if err := sendSpecialKeyFn(target, "Enter"); err != nil {
+		return fmt.Errorf("send enter: %w", err)
+	}
+
+	// Enforce single identity AFTER quickstart command is sent
+	// successfully. Quickstart runs asynchronously in the pane —
+	// this cleans pre-existing stale identities. The new identity
+	// will be written by quickstart.
+	//
+	// thrum-182j: mirror agent.go's keeper-list expansion so every
+	// agent registered against this worktree in session_refs survives
+	// enforcement. Liveness gate (IsPIDAlive) refuses to quarantine a
+	// file whose owning agent is currently running.
+	//
+	// AllowCrossWorktree is intentionally true: HandleCreate
+	// legitimately operates on a target worktree (req.Cwd) that is NOT
+	// the caller's own cwd — the coordinator creating a pane in a
+	// sibling worktree is the canonical use case.
+	keepers := []string{req.AgentName}
+	if h.state != nil {
+		keepers = append(keepers, h.state.ListAgentsInWorktree(ctx, req.Cwd)...)
+	}
+	worktree.EnforceOneIdentityWith(req.Cwd, worktree.EnforceOpts{
+		IsPIDAlive:         func(pid int) bool { return process.IsRunning(pid) },
+		AllowCrossWorktree: true,
+	}, keepers...)
+
+	// Shell init (oh-my-zsh, etc.) can swallow the first send-keys.
+	// Block until the identity file lands on disk: a back-to-back
+	// `thrum tmux launch` would otherwise find zero identity files
+	// (pre-fix this ran in a goroutine — thrum-ns0b).
+	idDir := filepath.Join(req.Cwd, ".thrum", "identities")
+	idPath := filepath.Join(idDir, req.AgentName+".json")
+	if resolved, err := filepath.EvalSymlinks(idDir); err == nil {
+		idPath = filepath.Join(resolved, req.AgentName+".json")
+	}
+	resend := func() error {
+		slog.Info("tmux.create.quickstart-resending",
+			slog.String("agent", req.AgentName), slog.String("session", name),
+		)
+		if err := sendKeysFn(target, quickstartCmd); err != nil {
+			return err
+		}
+		return sendSpecialKeyFn(target, "Enter")
+	}
+	if err := waitForIdentityFile(ctx, idPath, 5*time.Second, 5*time.Second, resend); err != nil {
+		slog.Warn("tmux.create.quickstart-timeout",
+			slog.String("agent", req.AgentName),
+			slog.String("session", name),
+			slog.String("err", err.Error()),
+		)
+		_ = killSessionFn(name)
+		return fmt.Errorf("tmux create: %w", err)
+	}
+	return nil
 }
 
 // buildInlineQuickstartCmd returns the shell-safe quickstart command

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -332,28 +332,40 @@ func (h *TmuxHandler) HandleCreate(ctx context.Context, params json.RawMessage) 
 		}, keepers...)
 
 		// Shell init (oh-my-zsh, etc.) can swallow the first command.
-		// Poll for the identity file; if it doesn't appear, re-send quickstart.
-		go func() {
-			idDir := filepath.Join(req.Cwd, ".thrum", "identities")
-			idPath := filepath.Join(idDir, req.AgentName+".json")
-			// Follow redirect symlink if present
-			if resolved, err := filepath.EvalSymlinks(idDir); err == nil {
-				idPath = filepath.Join(resolved, req.AgentName+".json")
+		// Block until the identity file lands on disk: quickstart is
+		// inherently async (runs in the pane's shell), but the CLI
+		// caller typically chains `thrum tmux launch` back-to-back and
+		// HandleLaunch needs the identity file present to bind
+		// tmux_session. thrum-ns0b: was a goroutine pre-fix; the race
+		// silently left tmux_session null on the launch side.
+		idDir := filepath.Join(req.Cwd, ".thrum", "identities")
+		idPath := filepath.Join(idDir, req.AgentName+".json")
+		if resolved, err := filepath.EvalSymlinks(idDir); err == nil {
+			idPath = filepath.Join(resolved, req.AgentName+".json")
+		}
+		resend := func() error {
+			slog.Info("tmux.create.quickstart-resending",
+				slog.String("agent", req.AgentName), slog.String("session", name),
+			)
+			if err := ttmux.SendKeys(target, quickstartCmd); err != nil {
+				return err
 			}
-
-			deadline := time.Now().Add(5 * time.Second)
-			for time.Now().Before(deadline) {
-				if _, err := os.Stat(idPath); err == nil {
-					return // quickstart succeeded
-				}
-				time.Sleep(500 * time.Millisecond)
-			}
-
-			// Identity not found — shell likely swallowed the command. Retry.
-			slog.Info("quickstart identity not found after 5s, retrying", "agent", req.AgentName, "session", name)
-			_ = ttmux.SendKeys(target, quickstartCmd)
-			_ = ttmux.SendSpecialKey(target, "Enter")
-		}()
+			return ttmux.SendSpecialKey(target, "Enter")
+		}
+		if err := waitForIdentityFile(idPath, 5*time.Second, 5*time.Second, resend); err != nil {
+			// Failure mode: quickstart never wrote the identity file
+			// even after a retry. Kill the tmux session so the caller
+			// doesn't see a half-initialized pane; return a structured
+			// error so the CLI caller can distinguish "create failed"
+			// from "create succeeded, launch failed."
+			slog.Warn("tmux.create.quickstart-timeout",
+				slog.String("agent", req.AgentName),
+				slog.String("session", name),
+				slog.String("err", err.Error()),
+			)
+			_ = ttmux.KillSession(name)
+			return nil, fmt.Errorf("tmux create: %w", err)
+		}
 	} else {
 		// For bare sessions, still write tmux_session to any existing identity
 		target := name + ":0.0"
@@ -1259,6 +1271,57 @@ func (h *TmuxHandler) findIdentityForSession(ctx context.Context, sessionName st
 		}
 	}
 	return "", nil, ""
+}
+
+// identityPollInterval is the cadence used by waitForIdentityFile to
+// stat the target path. Exposed as a var for test overrides; production
+// callers should not mutate at runtime.
+var identityPollInterval = 500 * time.Millisecond
+
+// waitForIdentityFile blocks until the identity file at idPath appears
+// on disk, or the combined initial+retry window expires. Between the
+// two windows, `resend` is invoked once — shell init (oh-my-zsh etc.)
+// can swallow the first send-keys, and a second attempt usually lands.
+//
+// Returns nil on success. On resend-function failure the wrapped error
+// is returned immediately. On combined-timeout a descriptive error is
+// returned including the total window waited.
+//
+// Pre thrum-ns0b this logic ran in a background goroutine, so
+// HandleCreate returned before the identity file existed. That raced
+// a back-to-back `thrum tmux launch` which could not find any identity
+// files to bind tmux_session to (writeTmuxToIdentity fell through all
+// three passes). Running synchronously closes the race at the cost of
+// up to ~10s latency on HandleCreate when the shell is slow.
+func waitForIdentityFile(idPath string, initial, retry time.Duration, resend func() error) error {
+	if waitUntilExists(idPath, initial) {
+		return nil
+	}
+	if resend != nil {
+		if err := resend(); err != nil {
+			return fmt.Errorf("re-send quickstart after initial %s wait: %w", initial, err)
+		}
+	}
+	if waitUntilExists(idPath, retry) {
+		return nil
+	}
+	return fmt.Errorf("quickstart did not write identity file %s within %s", idPath, initial+retry)
+}
+
+// waitUntilExists polls idPath every identityPollInterval up to the
+// given duration. Returns true as soon as os.Stat succeeds.
+func waitUntilExists(path string, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(identityPollInterval)
+	}
+	// One final check at the deadline, in case the sleep-tick landed
+	// on us just as the file appeared.
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // buildInlineQuickstartCmd returns the shell-safe quickstart command

--- a/internal/daemon/rpc/tmux_create_sync_test.go
+++ b/internal/daemon/rpc/tmux_create_sync_test.go
@@ -1,0 +1,121 @@
+package rpc
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests cover the synchronous identity-file wait that HandleCreate
+// uses to block until the inline quickstart has written the identity
+// file. Prior to thrum-ns0b the wait was async (goroutine), which races
+// with a back-to-back `thrum tmux launch` call and causes
+// writeTmuxToIdentity to find zero identity files.
+
+func TestWaitForIdentityFile_ExistsImmediately_ReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "impl_test.json")
+	if err := os.WriteFile(path, []byte(`{"version":4}`), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	resendCount := int32(0)
+	resend := func() error { atomic.AddInt32(&resendCount, 1); return nil }
+
+	start := time.Now()
+	if err := waitForIdentityFile(path, 500*time.Millisecond, 500*time.Millisecond, resend); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if atomic.LoadInt32(&resendCount) != 0 {
+		t.Errorf("expected no resend when file already exists, got %d", resendCount)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Errorf("expected near-instant return, took %v", elapsed)
+	}
+}
+
+func TestWaitForIdentityFile_CreatedDuringInitialWindow_NoResend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "impl_test.json")
+
+	resendCount := int32(0)
+	resend := func() error { atomic.AddInt32(&resendCount, 1); return nil }
+
+	// Create the file ~200ms into the initial wait.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		_ = os.WriteFile(path, []byte(`{"version":4}`), 0o600)
+	}()
+
+	if err := waitForIdentityFile(path, 1*time.Second, 1*time.Second, resend); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if atomic.LoadInt32(&resendCount) != 0 {
+		t.Errorf("expected no resend (file appeared in initial window), got %d", resendCount)
+	}
+}
+
+func TestWaitForIdentityFile_MissingInitial_ResendAndSucceed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "impl_test.json")
+
+	resendCount := int32(0)
+	resend := func() error {
+		atomic.AddInt32(&resendCount, 1)
+		// On resend, create the file (simulates shell swallowing the
+		// first send and picking up the second).
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			_ = os.WriteFile(path, []byte(`{"version":4}`), 0o600)
+		}()
+		return nil
+	}
+
+	if err := waitForIdentityFile(path, 200*time.Millisecond, 500*time.Millisecond, resend); err != nil {
+		t.Fatalf("expected nil error after resend, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&resendCount); got != 1 {
+		t.Errorf("expected exactly one resend, got %d", got)
+	}
+}
+
+func TestWaitForIdentityFile_NeverAppears_ReturnsTimeoutError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "impl_test.json")
+
+	resendCount := int32(0)
+	resend := func() error { atomic.AddInt32(&resendCount, 1); return nil }
+
+	start := time.Now()
+	err := waitForIdentityFile(path, 100*time.Millisecond, 100*time.Millisecond, resend)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if atomic.LoadInt32(&resendCount) != 1 {
+		t.Errorf("expected exactly one resend attempt, got %d", resendCount)
+	}
+	// Should take at least the full budget (initial + retry).
+	if elapsed < 150*time.Millisecond {
+		t.Errorf("expected wait to consume full budget (~200ms), took %v", elapsed)
+	}
+}
+
+func TestWaitForIdentityFile_ResendError_Propagates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "impl_test.json")
+	resendErr := errors.New("send failed")
+	resend := func() error { return resendErr }
+
+	err := waitForIdentityFile(path, 50*time.Millisecond, 50*time.Millisecond, resend)
+	if err == nil {
+		t.Fatal("expected resend error to propagate, got nil")
+	}
+	if !errors.Is(err, resendErr) {
+		t.Errorf("expected error to wrap %v, got: %v", resendErr, err)
+	}
+}

--- a/internal/daemon/rpc/tmux_create_sync_test.go
+++ b/internal/daemon/rpc/tmux_create_sync_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -15,7 +16,19 @@ import (
 // with a back-to-back `thrum tmux launch` call and causes
 // writeTmuxToIdentity to find zero identity files.
 
+// shrinkPollInterval sets identityPollInterval to a small value for
+// the duration of a single test so the wait loop actually exercises
+// multiple iterations under short budgets. Restores the production
+// default via t.Cleanup.
+func shrinkPollInterval(t *testing.T) {
+	t.Helper()
+	prev := identityPollInterval
+	identityPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { identityPollInterval = prev })
+}
+
 func TestWaitForIdentityFile_ExistsImmediately_ReturnsNil(t *testing.T) {
+	shrinkPollInterval(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "impl_test.json")
 	if err := os.WriteFile(path, []byte(`{"version":4}`), 0o600); err != nil {
@@ -26,31 +39,33 @@ func TestWaitForIdentityFile_ExistsImmediately_ReturnsNil(t *testing.T) {
 	resend := func() error { atomic.AddInt32(&resendCount, 1); return nil }
 
 	start := time.Now()
-	if err := waitForIdentityFile(path, 500*time.Millisecond, 500*time.Millisecond, resend); err != nil {
+	if err := waitForIdentityFile(context.Background(), path, 500*time.Millisecond, 500*time.Millisecond, resend); err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
 	if atomic.LoadInt32(&resendCount) != 0 {
 		t.Errorf("expected no resend when file already exists, got %d", resendCount)
 	}
-	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
 		t.Errorf("expected near-instant return, took %v", elapsed)
 	}
 }
 
 func TestWaitForIdentityFile_CreatedDuringInitialWindow_NoResend(t *testing.T) {
+	shrinkPollInterval(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "impl_test.json")
 
 	resendCount := int32(0)
 	resend := func() error { atomic.AddInt32(&resendCount, 1); return nil }
 
-	// Create the file ~200ms into the initial wait.
+	// Create the file ~30ms into the initial wait — well within the
+	// 200ms initial window and past the first poll tick.
 	go func() {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(30 * time.Millisecond)
 		_ = os.WriteFile(path, []byte(`{"version":4}`), 0o600)
 	}()
 
-	if err := waitForIdentityFile(path, 1*time.Second, 1*time.Second, resend); err != nil {
+	if err := waitForIdentityFile(context.Background(), path, 200*time.Millisecond, 200*time.Millisecond, resend); err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
 	if atomic.LoadInt32(&resendCount) != 0 {
@@ -59,22 +74,23 @@ func TestWaitForIdentityFile_CreatedDuringInitialWindow_NoResend(t *testing.T) {
 }
 
 func TestWaitForIdentityFile_MissingInitial_ResendAndSucceed(t *testing.T) {
+	shrinkPollInterval(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "impl_test.json")
 
 	resendCount := int32(0)
 	resend := func() error {
 		atomic.AddInt32(&resendCount, 1)
-		// On resend, create the file (simulates shell swallowing the
-		// first send and picking up the second).
+		// On resend, create the file — simulates shell swallowing
+		// the first send and picking up the second.
 		go func() {
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 			_ = os.WriteFile(path, []byte(`{"version":4}`), 0o600)
 		}()
 		return nil
 	}
 
-	if err := waitForIdentityFile(path, 200*time.Millisecond, 500*time.Millisecond, resend); err != nil {
+	if err := waitForIdentityFile(context.Background(), path, 100*time.Millisecond, 200*time.Millisecond, resend); err != nil {
 		t.Fatalf("expected nil error after resend, got: %v", err)
 	}
 	if got := atomic.LoadInt32(&resendCount); got != 1 {
@@ -83,6 +99,7 @@ func TestWaitForIdentityFile_MissingInitial_ResendAndSucceed(t *testing.T) {
 }
 
 func TestWaitForIdentityFile_NeverAppears_ReturnsTimeoutError(t *testing.T) {
+	shrinkPollInterval(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "impl_test.json")
 
@@ -90,7 +107,7 @@ func TestWaitForIdentityFile_NeverAppears_ReturnsTimeoutError(t *testing.T) {
 	resend := func() error { atomic.AddInt32(&resendCount, 1); return nil }
 
 	start := time.Now()
-	err := waitForIdentityFile(path, 100*time.Millisecond, 100*time.Millisecond, resend)
+	err := waitForIdentityFile(context.Background(), path, 100*time.Millisecond, 100*time.Millisecond, resend)
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -99,23 +116,186 @@ func TestWaitForIdentityFile_NeverAppears_ReturnsTimeoutError(t *testing.T) {
 	if atomic.LoadInt32(&resendCount) != 1 {
 		t.Errorf("expected exactly one resend attempt, got %d", resendCount)
 	}
-	// Should take at least the full budget (initial + retry).
-	if elapsed < 150*time.Millisecond {
-		t.Errorf("expected wait to consume full budget (~200ms), took %v", elapsed)
+	// Full budget (100+100=200ms); allow modest slack. Upper bound
+	// catches the bug where we overshoot by a full poll interval.
+	if elapsed < 180*time.Millisecond {
+		t.Errorf("expected wait to consume full budget, took %v", elapsed)
+	}
+	if elapsed > 300*time.Millisecond {
+		t.Errorf("expected wait to stay close to full budget (200ms), overshot to %v", elapsed)
 	}
 }
 
 func TestWaitForIdentityFile_ResendError_Propagates(t *testing.T) {
+	shrinkPollInterval(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "impl_test.json")
 	resendErr := errors.New("send failed")
 	resend := func() error { return resendErr }
 
-	err := waitForIdentityFile(path, 50*time.Millisecond, 50*time.Millisecond, resend)
+	err := waitForIdentityFile(context.Background(), path, 50*time.Millisecond, 50*time.Millisecond, resend)
 	if err == nil {
 		t.Fatal("expected resend error to propagate, got nil")
 	}
 	if !errors.Is(err, resendErr) {
 		t.Errorf("expected error to wrap %v, got: %v", resendErr, err)
+	}
+}
+
+// TestRunInlineQuickstart_BlocksUntilIdentityFileExists is the
+// RPC-boundary regression test. A future refactor that moves the
+// identity wait back into a background goroutine would pass every
+// waitForIdentityFile unit test while silently re-introducing the
+// thrum-ns0b race. This test pins the invariant at the method that
+// HandleCreate actually calls: the send-keys side-effect must have
+// written the file before runInlineQuickstart returns.
+//
+// Uses the sendKeysFn / sendSpecialKeyFn package-var seams to
+// simulate a shell that creates the identity file ~20ms after the
+// quickstart command is received — a real shell runs much slower,
+// but the shape is identical.
+func TestRunInlineQuickstart_BlocksUntilIdentityFileExists(t *testing.T) {
+	shrinkPollInterval(t)
+
+	cwd := t.TempDir()
+	idDir := filepath.Join(cwd, ".thrum", "identities")
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	idPath := filepath.Join(idDir, "impl_x.json")
+
+	// Swap in fakes that simulate the pane's shell running quickstart.
+	// sendKeys writes the identity file on a delay, mimicking the
+	// real async-shell behavior.
+	prevSend := sendKeysFn
+	prevEnter := sendSpecialKeyFn
+	prevKill := killSessionFn
+	t.Cleanup(func() {
+		sendKeysFn = prevSend
+		sendSpecialKeyFn = prevEnter
+		killSessionFn = prevKill
+	})
+
+	var fileWrittenAtNS atomic.Int64 // unix nanos
+	sendKeysFn = func(_, _ string) error {
+		go func() {
+			time.Sleep(30 * time.Millisecond)
+			fileWrittenAtNS.Store(time.Now().UnixNano())
+			_ = os.WriteFile(idPath, []byte(`{"version":4}`), 0o600)
+		}()
+		return nil
+	}
+	sendSpecialKeyFn = func(_, _ string) error { return nil }
+	killSessionFn = func(_ string) error {
+		t.Error("killSessionFn must not be called on the happy path")
+		return nil
+	}
+
+	h := NewTmuxHandler(t.TempDir(), nil)
+	req := TmuxCreateRequest{
+		AgentName: "impl_x",
+		Role:      "implementer",
+		Module:    "testing",
+		Cwd:       cwd,
+	}
+
+	if err := h.runInlineQuickstart(context.Background(), req, "sess"); err != nil {
+		t.Fatalf("runInlineQuickstart: %v", err)
+	}
+	runReturnedAtNS := time.Now().UnixNano()
+
+	writtenNS := fileWrittenAtNS.Load()
+	if writtenNS == 0 {
+		t.Fatal("file was never written (the fake send-keys closure didn't run)")
+	}
+	if runReturnedAtNS < writtenNS {
+		t.Errorf("regression: runInlineQuickstart returned at %d BEFORE the identity file appeared at %d — "+
+			"this means the wait was async again (thrum-ns0b regression)",
+			runReturnedAtNS, writtenNS)
+	}
+	if _, err := os.Stat(idPath); err != nil {
+		t.Errorf("identity file should exist after runInlineQuickstart returns, got: %v", err)
+	}
+}
+
+// TestRunInlineQuickstart_TimeoutKillsSessionAndErrors verifies the
+// failure path: when the shell never writes the identity file, the
+// method kills the session (so callers don't see a half-initialized
+// pane) and returns a structured error.
+func TestRunInlineQuickstart_TimeoutKillsSessionAndErrors(t *testing.T) {
+	shrinkPollInterval(t)
+
+	cwd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cwd, ".thrum", "identities"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	prevSend := sendKeysFn
+	prevEnter := sendSpecialKeyFn
+	prevKill := killSessionFn
+	t.Cleanup(func() {
+		sendKeysFn = prevSend
+		sendSpecialKeyFn = prevEnter
+		killSessionFn = prevKill
+	})
+
+	// Shrink the production 5s+5s budget to 30ms+30ms via a dedicated
+	// test seam: use very small identityPollInterval + the
+	// waitForIdentityFile timing is gated by the method's hardcoded
+	// 5s values, so this test would take 10s without further factoring.
+	// Instead: swap in a no-op sendKeysFn (file never appears) AND
+	// cancel via ctx after 50ms.
+	killedSession := ""
+	sendKeysFn = func(_, _ string) error { return nil }
+	sendSpecialKeyFn = func(_, _ string) error { return nil }
+	killSessionFn = func(name string) error {
+		killedSession = name
+		return nil
+	}
+
+	h := NewTmuxHandler(t.TempDir(), nil)
+	req := TmuxCreateRequest{
+		AgentName: "impl_x", Role: "implementer", Module: "testing", Cwd: cwd,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := h.runInlineQuickstart(ctx, req, "sess-fail")
+	if err == nil {
+		t.Fatal("expected error when identity file never appears")
+	}
+	if killedSession != "sess-fail" {
+		t.Errorf("expected session 'sess-fail' to be killed on timeout, killedSession=%q", killedSession)
+	}
+}
+
+// TestWaitForIdentityFile_ContextCancelled_ReturnsPromptly verifies
+// that a client disconnect / daemon shutdown mid-wait returns ctx.Err()
+// instead of burning the full budget. Without ctx-awareness the whole
+// 10s production deadline would have to elapse before the RPC returns.
+func TestWaitForIdentityFile_ContextCancelled_ReturnsPromptly(t *testing.T) {
+	shrinkPollInterval(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "impl_test.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := waitForIdentityFile(ctx, path, 5*time.Second, 5*time.Second, func() error {
+		t.Error("resend should not be called when ctx cancels during initial wait")
+		return nil
+	})
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("expected prompt return on cancel, took %v (would have taken 10s without ctx-awareness)", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes **thrum-ns0b**: `HandleCreate` returned before the inline quickstart had written the identity file. Back-to-back `thrum tmux create + thrum tmux launch` (the coordinator-initiated restart flow) raced — `HandleLaunch`'s `writeTmuxToIdentity` found zero identity files across all three passes and silently left `tmux_session` null.

thrum-nu16 fixed the dead-PID branch of the same cascade. This PR closes the empty-worktree branch by making HandleCreate synchronous with respect to identity-file creation.

## Changes

- **New helper** `waitForIdentityFile(idPath, initial, retry, resend)` in `internal/daemon/rpc/tmux.go`: two-phase poll with a single explicit resend between windows. Returns a structured error on final timeout.
- **HandleCreate** now calls `waitForIdentityFile` inline (was a goroutine that returned before the wait finished). On timeout, the tmux session is torn down via `ttmux.KillSession` so callers don't see a half-initialized pane; a structured `tmux create: ...` error is returned.
- `slog.Info` on resend + `slog.Warn` on timeout for observability.
- `identityPollInterval` exposed as a package var so tests can tune cadence.
- **5 new unit tests** covering all the behavioral branches of `waitForIdentityFile` (exists-immediately, created-during-initial, resend-then-succeed, never-appears-timeout, resend-error propagation).

## Test plan

- [x] `go test -race ./internal/daemon/rpc/` — full suite green, 5 new `TestWaitForIdentityFile_*` tests pass
- [x] `go test -race ./...` — no regressions
- [ ] Manual Step 10.1 repro from `full_test_plan.md` without explicit `sleep` between `thrum tmux create` and `thrum tmux launch` (this is the acceptance criterion from the bead)

## Design decisions

- **Synchronous wait vs. keep goroutine + "wait-for-identity" status flag.** Went with synchronous. The bead's option B is the simpler shape, the ~10s worst-case latency only bites on shell-init flake, and the alternative (returning early + letting caller poll) forces every CLI caller to learn a new retry dance. Synchronous also means the CLI's existing error-path handling catches the failure mode cleanly.
- **Kill session on timeout vs. leave as zombie.** Killed. A zombie session after a timeout is worse UX than a clean "create failed" — the caller can re-run `thrum tmux create` without first hunting down the stale session. The inline quickstart's running command in the pane dies with it, but at ~10s wallclock it has already demonstrated the shell can't reliably pick up the send-keys.
- **Integration test.** Comprehensive unit tests cover every waitForIdentityFile branch. A full HandleCreate integration test would need daemon+real-tmux+git-worktree bootstrap plus a way to actually run `thrum quickstart` in the pane — out of scope for a quick fix. Step 10.1 manual repro is the acceptance gate.

## Fixes

- Closes thrum-ns0b