### PR TITLE
fix: upgrade 3 worktree-field consumers to accept path or name (thrum-8bza)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,12 +225,23 @@ func loadIdentityFromDir(dirPath string, thrumName string) (*IdentityFile, error
 		}
 	}
 
-	// Pass 1: Worktree-based filtering
+	// Pass 1: Worktree-based filtering. currentWT is an absolute path
+	// (thrum-8bza). idFile.Worktree may be either shape: absolute path
+	// (post thrum-x6e8.2 / nu16) or a bare name (legacy fixtures, in
+	// the process of being self-healed by reconcileDrift). Accept both.
 	currentWT := detectCurrentWorktree(dirPath)
 	if currentWT != "" {
+		currentBasename := filepath.Base(currentWT)
 		var matches []*IdentityFile
 		for _, id := range identities {
+			if id.Worktree == "" {
+				continue
+			}
 			if id.Worktree == currentWT {
+				matches = append(matches, id)
+				continue
+			}
+			if !filepath.IsAbs(id.Worktree) && id.Worktree == currentBasename {
 				matches = append(matches, id)
 			}
 		}
@@ -253,7 +264,16 @@ func loadIdentityFromDir(dirPath string, thrumName string) (*IdentityFile, error
 		len(jsonFiles), strings.Join(available, ", "))
 }
 
-// detectCurrentWorktree returns the current git worktree name, or "" if detection fails.
+// detectCurrentWorktree returns the absolute path of the current git
+// worktree, or "" if detection fails.
+//
+// thrum-8bza: previously returned filepath.Base(toplevel) so the Pass 1
+// comparison at loadIdentityFromDir could match idFile.Worktree's
+// bare-name form. After thrum-x6e8.2 / nu16, identity files store the
+// full path, so this helper aligns by also returning the full path.
+// Legacy bare-name identity files self-heal via reconcileDrift on the
+// next guard.Check pass; during that window Pass 1 just falls through
+// to the generic ambiguous-identity error (same behavior as zero-match).
 func detectCurrentWorktree(identitiesDir string) string {
 	// identitiesDir is .thrum/identities/ — go up two levels to get repo root
 	repoRoot := filepath.Dir(filepath.Dir(identitiesDir))
@@ -261,7 +281,7 @@ func detectCurrentWorktree(identitiesDir string) string {
 	if err != nil {
 		return ""
 	}
-	return filepath.Base(strings.TrimSpace(string(out)))
+	return filepath.Clean(strings.TrimSpace(string(out)))
 }
 
 // LoadIdentityFromWorktree reads the agent identity from a specific worktree

--- a/internal/config/detect_worktree_test.go
+++ b/internal/config/detect_worktree_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestDetectCurrentWorktree_ReturnsAbsolutePath covers thrum-8bza.
+// Prior to the fix, detectCurrentWorktree returned the basename so the
+// Pass 1 comparison at loadIdentityFromDir matched legacy bare-name
+// identity files. Post thrum-x6e8.2/nu16 identity files store absolute
+// paths; this helper now returns absolute paths to match.
+func TestDetectCurrentWorktree_ReturnsAbsolutePath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "-C", repo, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, out)
+	}
+
+	identitiesDir := filepath.Join(repo, ".thrum", "identities")
+
+	got := detectCurrentWorktree(identitiesDir)
+	if got == "" {
+		t.Fatalf("expected non-empty result for valid git repo")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("expected absolute path, got %q", got)
+	}
+	// macOS may alias /var → /private/var, so compare via EvalSymlinks.
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	wantResolved, _ := filepath.EvalSymlinks(repo)
+	if filepath.Clean(gotResolved) != filepath.Clean(wantResolved) &&
+		filepath.Clean(got) != filepath.Clean(repo) {
+		t.Errorf("expected %q or %q, got %q", repo, wantResolved, got)
+	}
+}
+
+func TestDetectCurrentWorktree_NotGitRepo_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	identitiesDir := filepath.Join(dir, ".thrum", "identities")
+	if got := detectCurrentWorktree(identitiesDir); got != "" {
+		t.Errorf("expected empty for non-git dir, got %q", got)
+	}
+}
+
+// TestLoad_WorktreeFiltering_AbsolutePathWorktree verifies that Pass 1
+// matches identity files whose Worktree field is an absolute path (the
+// post thrum-x6e8.2 / nu16 shape). The existing
+// TestLoad_WorktreeFiltering_SingleMatch covers the legacy bare-name
+// shape; this test covers the path shape so both branches of the
+// thrum-8bza fix are exercised.
+func TestLoad_WorktreeFiltering_AbsolutePathWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	t.Setenv("THRUM_HOME", "")
+	t.Setenv("THRUM_NAME", "")
+	t.Setenv("THRUM_AGENT_ID", "")
+
+	tmpDir := t.TempDir()
+	if out, err := exec.Command("git", "-C", tmpDir, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, out)
+	}
+	// macOS aliases /var → /private/var; `git rev-parse --show-toplevel`
+	// returns the resolved path, so the identity file's Worktree field
+	// (which reconcileDrift also writes via EvalSymlinks) must match.
+	resolvedTmp, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+
+	thrumDir := filepath.Join(tmpDir, ".thrum")
+	// Match: worktree is an absolute path == current repo
+	matching := &IdentityFile{
+		Version:  1,
+		RepoID:   "r_TEST123",
+		Worktree: resolvedTmp, // absolute path (post-nu16 shape)
+		Agent: AgentConfig{
+			Kind: "agent", Name: "matching_agent", Role: "implementer", Module: "test",
+		},
+	}
+	// No match: different absolute path
+	other := &IdentityFile{
+		Version:  1,
+		RepoID:   "r_TEST123",
+		Worktree: "/nonexistent/other/path",
+		Agent: AgentConfig{
+			Kind: "agent", Name: "other_agent", Role: "tester", Module: "test",
+		},
+	}
+	if err := SaveIdentityFile(thrumDir, matching); err != nil {
+		t.Fatalf("save matching: %v", err)
+	}
+	if err := SaveIdentityFile(thrumDir, other); err != nil {
+		t.Fatalf("save other: %v", err)
+	}
+
+	cfg, err := LoadWithPath(tmpDir, "", "")
+	if err != nil {
+		t.Fatalf("LoadWithPath: %v", err)
+	}
+	if cfg.Agent.Name != "matching_agent" {
+		t.Errorf("expected 'matching_agent', got %q", cfg.Agent.Name)
+	}
+}

--- a/internal/daemon/rpc/agent.go
+++ b/internal/daemon/rpc/agent.go
@@ -1363,24 +1363,31 @@ func (h *AgentHandler) HandleCleanup(ctx context.Context, params json.RawMessage
 	}, nil
 }
 
-// worktreeExists checks if a worktree exists via git worktree list.
-func (h *AgentHandler) worktreeExists(ctx context.Context, worktreeName string) bool {
-	// Run git worktree list and check if worktree name appears
+// worktreeExists reports whether the stored worktree identifier maps
+// to a live directory. Accepts either an absolute path (post
+// thrum-x6e8.2 / nu16 identity files) or a bare basename (legacy).
+// For the absolute-path shape, os.Stat(stored) is authoritative. For
+// the bare-name shape, match against `git worktree list`.
+func (h *AgentHandler) worktreeExists(ctx context.Context, stored string) bool {
+	if stored == "" {
+		return false
+	}
+	if filepath.IsAbs(stored) {
+		_, err := os.Stat(stored)
+		return err == nil
+	}
+	// Legacy bare-name fallback — consult git worktree list.
 	output, err := safecmd.Git(ctx, h.state.RepoPath(), "worktree", "list", "--porcelain")
 	if err != nil {
 		return false
 	}
-
-	// Parse output to find worktree
 	for line := range strings.SplitSeq(string(output), "\n") {
 		if path, ok := strings.CutPrefix(line, "worktree "); ok {
-			// Check if path ends with worktree name
-			if strings.HasSuffix(path, "/"+worktreeName) || strings.HasSuffix(path, "\\"+worktreeName) || filepath.Base(path) == worktreeName {
+			if strings.HasSuffix(path, "/"+stored) || strings.HasSuffix(path, "\\"+stored) || filepath.Base(path) == stored {
 				return true
 			}
 		}
 	}
-
 	return false
 }
 

--- a/internal/daemon/rpc/resolve_worktree_test.go
+++ b/internal/daemon/rpc/resolve_worktree_test.go
@@ -1,0 +1,150 @@
+package rpc
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/leonletto/thrum/internal/daemon/state"
+)
+
+// newAgentHandlerAt constructs an AgentHandler whose state.RepoPath()
+// points at repoPath (a real git repo created by the caller). Cleanup
+// is registered so the DB file is closed at test end.
+func newAgentHandlerAt(t *testing.T, repoPath string) *AgentHandler {
+	t.Helper()
+	thrumDir := filepath.Join(repoPath, ".thrum")
+	if err := os.MkdirAll(thrumDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	st, err := state.NewState(thrumDir, thrumDir, "r_thrum_8bza_test", "")
+	if err != nil {
+		t.Fatalf("new state: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return NewAgentHandler(st)
+}
+
+// TestResolveWorktreePath covers thrum-8bza: resolveWorktreePath must
+// accept both legacy bare-name inputs and post-thrum-x6e8.2 absolute-
+// path inputs. Without this, `thrum tmux restart` fails on any identity
+// file written post-nu16 because its Worktree field is a path but the
+// git-worktree-list matcher compares against basename.
+func TestResolveWorktreePath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Create a real git repo so the legacy-name fallback (git worktree
+	// list) has something to match.
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "-C", repo, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, out)
+	}
+
+	ctx := context.Background()
+
+	t.Run("absolute_path_exists_returns_path", func(t *testing.T) {
+		got := resolveWorktreePath(ctx, repo, repo)
+		if got == "" {
+			t.Fatalf("expected non-empty result for existing abs path")
+		}
+		// macOS may return /private/var/... for /var/...; resolve both
+		// and compare.
+		gotResolved, _ := filepath.EvalSymlinks(got)
+		wantResolved, _ := filepath.EvalSymlinks(repo)
+		if filepath.Clean(gotResolved) != filepath.Clean(wantResolved) &&
+			filepath.Clean(got) != filepath.Clean(repo) {
+			t.Errorf("expected %q or %q, got %q", repo, wantResolved, got)
+		}
+	})
+
+	t.Run("absolute_path_missing_returns_empty", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+		if got := resolveWorktreePath(ctx, repo, missing); got != "" {
+			t.Errorf("expected empty for missing abs path, got %q", got)
+		}
+	})
+
+	t.Run("legacy_basename_match_returns_path", func(t *testing.T) {
+		// Legacy-name path: basename(repo) == stored → return repo path.
+		name := filepath.Base(repo)
+		got := resolveWorktreePath(ctx, repo, name)
+		// git worktree list on a bare repo without any added worktrees
+		// lists the main repo itself. The resolver should find it.
+		if got == "" {
+			t.Fatalf("expected legacy basename match to resolve, got empty (name=%q, repo=%q)", name, repo)
+		}
+	})
+
+	t.Run("legacy_basename_nomatch_returns_empty", func(t *testing.T) {
+		if got := resolveWorktreePath(ctx, repo, "completely-unknown-worktree-xxx"); got != "" {
+			t.Errorf("expected empty for unmatched legacy name, got %q", got)
+		}
+	})
+
+	t.Run("empty_input_returns_empty", func(t *testing.T) {
+		if got := resolveWorktreePath(ctx, repo, ""); got != "" {
+			t.Errorf("expected empty for empty input, got %q", got)
+		}
+	})
+}
+
+// TestWorktreeExists_PathAware covers thrum-8bza for
+// AgentHandler.worktreeExists: must accept both bare name and absolute
+// path. Without this, orphan-agent detection (agent.cleanup) silently
+// mis-flags live worktrees whose identity files store absolute paths.
+func TestWorktreeExists_PathAware(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "-C", repo, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, out)
+	}
+
+	// worktreeExists needs a state with RepoPath; it's daemon-side, so
+	// we wire through the daemon's state.State. For focused unit
+	// testing we use a nil-state handler only at the shape-level.
+	// The method only calls h.state.RepoPath() — construct via the
+	// same newAgentHandlerForTest pattern other tests in this package
+	// use. Since there isn't one, skip nil-state branches and test
+	// the logic via a focused helper.
+	//
+	// Simpler: test the behavior by direct filesystem assertions via
+	// a small handler wrapper — but that forks the logic. Instead:
+	// rely on git-repo-in-tempdir + real state setup from existing
+	// testhelpers. Use the same scaffolding as TestTmuxHandler_HandleCreate.
+	t.Run("absolute_path_exists_returns_true", func(t *testing.T) {
+		h := newAgentHandlerAt(t, repo)
+		if !h.worktreeExists(context.Background(), repo) {
+			t.Errorf("expected true for existing absolute path %q", repo)
+		}
+	})
+
+	t.Run("absolute_path_missing_returns_false", func(t *testing.T) {
+		h := newAgentHandlerAt(t, repo)
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+		if h.worktreeExists(context.Background(), missing) {
+			t.Errorf("expected false for missing absolute path %q", missing)
+		}
+	})
+
+	t.Run("legacy_basename_match_returns_true", func(t *testing.T) {
+		h := newAgentHandlerAt(t, repo)
+		if !h.worktreeExists(context.Background(), filepath.Base(repo)) {
+			t.Errorf("expected true for legacy basename %q", filepath.Base(repo))
+		}
+	})
+
+	t.Run("legacy_basename_nomatch_returns_false", func(t *testing.T) {
+		h := newAgentHandlerAt(t, repo)
+		if h.worktreeExists(context.Background(), "completely-unknown-xxx") {
+			t.Errorf("expected false for unmatched legacy name")
+		}
+	})
+}
+

--- a/internal/daemon/rpc/resolve_worktree_test.go
+++ b/internal/daemon/rpc/resolve_worktree_test.go
@@ -146,5 +146,12 @@ func TestWorktreeExists_PathAware(t *testing.T) {
 			t.Errorf("expected false for unmatched legacy name")
 		}
 	})
+
+	t.Run("empty_input_returns_false", func(t *testing.T) {
+		h := newAgentHandlerAt(t, repo)
+		if h.worktreeExists(context.Background(), "") {
+			t.Errorf("expected false for empty input")
+		}
+	})
 }
 

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -1113,15 +1113,38 @@ func primeCommandForRuntime(runtime string) string {
 	}
 }
 
-// resolveWorktreePath uses git worktree list to find the absolute path for a worktree name.
-func resolveWorktreePath(ctx context.Context, repoDir, worktreeName string) string {
+// resolveWorktreePath returns the absolute worktree path for the
+// stored identifier, which may be either an absolute path (post
+// thrum-x6e8.2 / nu16 identity files) or a bare basename (legacy
+// identity files written before nu16, rewritten to absolute by
+// reconcileDrift on next guard.Check).
+//
+// For the path shape: if stored stat()s, return filepath.Clean(stored).
+// Otherwise return "" — don't fall back to basename lookup, since the
+// caller stored a specific path and expects an unambiguous answer.
+//
+// For the bare-name shape: fall back to `git worktree list` and match
+// by basename (legacy behavior).
+//
+// Returns "" if neither form resolves.
+func resolveWorktreePath(ctx context.Context, repoDir, stored string) string {
+	if stored == "" {
+		return ""
+	}
+	if filepath.IsAbs(stored) {
+		if _, err := os.Stat(stored); err == nil {
+			return filepath.Clean(stored)
+		}
+		return ""
+	}
+	// Legacy bare-name fallback — consult git worktree list.
 	out, err := safecmd.Git(ctx, repoDir, "worktree", "list", "--porcelain")
 	if err != nil {
 		return ""
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		if path, ok := strings.CutPrefix(line, "worktree "); ok {
-			if filepath.Base(path) == worktreeName {
+			if filepath.Base(path) == stored {
 				return path
 			}
 		}

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -941,11 +941,17 @@ func (h *TmuxHandler) HandleRestart(ctx context.Context, params json.RawMessage)
 	}
 
 	// Resolve worktree to path BEFORE killing — if resolution fails, keep the session alive.
-	// IdentityFile.Worktree is a bare name like "team-fix".
+	// idFile.Worktree may be an absolute path (post thrum-x6e8.2 / nu16)
+	// OR a bare name like "team-fix" (legacy — rewritten on next
+	// guard.Check via reconcileDrift). resolveWorktreePath handles both.
 	repoDir := filepath.Dir(h.thrumDir)
 	cwd := resolveWorktreePath(ctx, repoDir, idFile.Worktree)
 	if cwd == "" {
-		// Fallback: if worktree matches the repo itself
+		// Legacy-only fallback: caller is inside the main repo itself
+		// and stored a bare name matching filepath.Base(repoDir). This
+		// branch is dead for the abs-path shape (an absolute path can
+		// never equal a basename) but remains valid for bare-name
+		// identity files that haven't yet been reconciled.
 		if filepath.Base(repoDir) == idFile.Worktree || idFile.Worktree == "" {
 			cwd = repoDir
 		}


### PR DESCRIPTION
## Summary

Fixes **thrum-8bza**: thrum-nu16 / x6e8.2 changed `identity.Worktree` from a bare basename to an absolute path, but 3 downstream consumers still compared against basename-extracted-name:

- `internal/daemon/rpc/tmux.go:1117` `resolveWorktreePath` (HandleRestart)
- `internal/daemon/rpc/agent.go:1367` `worktreeExists` (orphan-agent check)
- `internal/config/config.go:266` `detectCurrentWorktree` (loadIdentityFromDir Pass 1)

Symptom that unblocks release-test Step 10.4:

```
$ thrum tmux restart test-impl
error: cannot resolve worktree "/Users/.../test-implementer" to a path for test_implementer
```

## Approach (Option B)

Upgrade the 3 helpers to be path-aware; caller sites stay unchanged. Each helper was confirmed to have exactly one non-test caller — no ripple.

1. **`resolveWorktreePath`** — if `stored` is absolute, `stat()` is authoritative: return `filepath.Clean(stored)` or "" on miss. Else legacy `git worktree list` basename match.
2. **`worktreeExists`** — if `stored` is absolute, `os.Stat(stored)`. Else legacy `git worktree list` scan (HasSuffix + basename branches preserved for the legacy shapes).
3. **`detectCurrentWorktree`** — returns `filepath.Clean(rev-parse --show-toplevel)` (was `filepath.Base(...)`). Pass 1 comparison at `loadIdentityFromDir` extended to match **both** shapes (absolute-vs-absolute OR basename-vs-basename) so bare-name legacy fixtures still resolve during the reconcileDrift self-heal window.

## Changes

- `internal/daemon/rpc/tmux.go` — `resolveWorktreePath` path-aware.
- `internal/daemon/rpc/agent.go` — `worktreeExists` path-aware.
- `internal/config/config.go` — `detectCurrentWorktree` returns absolute path; Pass 1 match accepts either shape.
- `internal/daemon/rpc/resolve_worktree_test.go` **(new)** — 5-case table test for `resolveWorktreePath` + 4-case for `worktreeExists` (real `git init` + `newAgentHandlerAt` scaffolding).
- `internal/config/detect_worktree_test.go` **(new)** — `TestDetectCurrentWorktree_ReturnsAbsolutePath`, `_NotGitRepo_ReturnsEmpty`, `TestLoad_WorktreeFiltering_AbsolutePathWorktree`.

## Test plan

- [x] `go test -race ./internal/daemon/rpc/` — green
- [x] `go test -race ./internal/config/` — green (pre-existing legacy-shape tests still pass alongside the new absolute-path tests)
- [x] `go test -race ./internal/identity/guard/` — green (no regression)
- [x] 11 new unit tests across the 3 sites
- [ ] Acceptance gate: Step 10.4 `thrum tmux restart test-impl` end-to-end (coordinator's post-merge run)

## Why B over A

Coordinator's post-audit: each of the 3 helpers has exactly one non-test caller. Centralizing the compatibility in the helpers (B) keeps call sites clean and matches the post-nu16 reality (identity stores paths). A would scatter 3 `filepath.Base` calls at the call sites.

Closes thrum-8bza.