### PR TITLE
fix: tmux no-agent send + status + beads redirect confirmation (ufv5.11/12/13)

### DIFF
--- a/cmd/thrum/main.go
+++ b/cmd/thrum/main.go
@@ -2668,7 +2668,7 @@ func worktreeCreateCmd() *cobra.Command {
 			if err := cli.EnsureWorktreeRedirects(worktreePath, repoPath); err != nil {
 				return fmt.Errorf("redirect setup: %w", err)
 			}
-			fmt.Println("✓ Thrum redirect configured")
+			cli.PrintRedirectConfirmations(os.Stdout, worktreePath)
 
 			// 3. Optional: create tmux session with agent quickstart
 			agentName, _ := cmd.Flags().GetString("name")

--- a/internal/cli/worktree.go
+++ b/internal/cli/worktree.go
@@ -21,14 +21,15 @@ func BuildQuickstartCmd(name, role, module, intent, runtime string, noAgentPID b
 }
 
 // PrintRedirectConfirmations writes one checkmark line per redirect
-// file EnsureRedirects created for worktreePath. The thrum redirect
-// is always expected; the beads redirect is conditional on the main
-// repo having .beads/ and is reported only when the file is actually
-// present on disk. Testable helper for thrum-ufv5.13 — callers in
-// cmd/thrum/main.go delegate here so output stays aligned with what
-// EnsureRedirects actually wrote.
+// file EnsureRedirects actually created for worktreePath. Both the
+// thrum line and the beads line are artifact-driven — we stat the
+// concrete file before printing, so output stays truthful even if the
+// conditions inside EnsureRedirects change later (thrum-ufv5.13,
+// review #6: both redirects get the same treatment for consistency).
 func PrintRedirectConfirmations(w io.Writer, worktreePath string) {
-	_, _ = fmt.Fprintln(w, "✓ Thrum redirect configured")
+	if _, err := os.Stat(filepath.Join(worktreePath, ".thrum", "redirect")); err == nil {
+		_, _ = fmt.Fprintln(w, "✓ Thrum redirect configured")
+	}
 	if _, err := os.Stat(filepath.Join(worktreePath, ".beads", "redirect")); err == nil {
 		_, _ = fmt.Fprintln(w, "✓ Beads redirect configured")
 	}

--- a/internal/cli/worktree.go
+++ b/internal/cli/worktree.go
@@ -1,6 +1,13 @@
 package cli
 
-import "github.com/leonletto/thrum/internal/worktree"
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/leonletto/thrum/internal/worktree"
+)
 
 // EnsureWorktreeRedirects delegates to worktree.EnsureRedirects.
 // Kept for backward compatibility with callers in cmd/thrum/main.go.
@@ -11,4 +18,18 @@ func EnsureWorktreeRedirects(worktreePath, mainRepo string) error {
 // BuildQuickstartCmd delegates to worktree.BuildQuickstartCmd.
 func BuildQuickstartCmd(name, role, module, intent, runtime string, noAgentPID bool) string {
 	return worktree.BuildQuickstartCmd(name, role, module, intent, runtime, noAgentPID)
+}
+
+// PrintRedirectConfirmations writes one checkmark line per redirect
+// file EnsureRedirects created for worktreePath. The thrum redirect
+// is always expected; the beads redirect is conditional on the main
+// repo having .beads/ and is reported only when the file is actually
+// present on disk. Testable helper for thrum-ufv5.13 — callers in
+// cmd/thrum/main.go delegate here so output stays aligned with what
+// EnsureRedirects actually wrote.
+func PrintRedirectConfirmations(w io.Writer, worktreePath string) {
+	_, _ = fmt.Fprintln(w, "✓ Thrum redirect configured")
+	if _, err := os.Stat(filepath.Join(worktreePath, ".beads", "redirect")); err == nil {
+		_, _ = fmt.Fprintln(w, "✓ Beads redirect configured")
+	}
 }

--- a/internal/cli/worktree_test.go
+++ b/internal/cli/worktree_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/leonletto/thrum/internal/worktree"
+)
+
+// TestPrintRedirectConfirmations_ThrumOnly asserts that when the main
+// repo has no .beads/ directory (and therefore EnsureRedirects did not
+// write a beads redirect), only the thrum line is printed.
+func TestPrintRedirectConfirmations_ThrumOnly(t *testing.T) {
+	tmp := t.TempDir()
+	mainRepo := filepath.Join(tmp, "main")
+	wt := filepath.Join(tmp, "wt")
+	if err := os.MkdirAll(filepath.Join(mainRepo, ".thrum"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(wt, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := worktree.EnsureRedirects(wt, mainRepo); err != nil {
+		t.Fatalf("EnsureRedirects: %v", err)
+	}
+
+	var buf bytes.Buffer
+	PrintRedirectConfirmations(&buf, wt)
+	got := buf.String()
+	if !strings.Contains(got, "Thrum redirect configured") {
+		t.Errorf("missing thrum line: %q", got)
+	}
+	if strings.Contains(got, "Beads redirect configured") {
+		t.Errorf("unexpected beads line when main repo has no .beads/: %q", got)
+	}
+}
+
+// TestPrintRedirectConfirmations_BothWhenBeadsPresent asserts that
+// when the main repo has .beads/ and EnsureRedirects wires up the
+// beads redirect, both confirmation lines appear. Regression guard
+// for thrum-ufv5.13 (Step 10B.2 expects explicit confirmation).
+func TestPrintRedirectConfirmations_BothWhenBeadsPresent(t *testing.T) {
+	tmp := t.TempDir()
+	mainRepo := filepath.Join(tmp, "main")
+	wt := filepath.Join(tmp, "wt")
+	for _, d := range []string{
+		filepath.Join(mainRepo, ".thrum"),
+		filepath.Join(mainRepo, ".beads"),
+		wt,
+	} {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := worktree.EnsureRedirects(wt, mainRepo); err != nil {
+		t.Fatalf("EnsureRedirects: %v", err)
+	}
+
+	// Sanity: the beads redirect file should now exist; the helper
+	// is driven by that artifact's presence.
+	if _, err := os.Stat(filepath.Join(wt, ".beads", "redirect")); err != nil {
+		t.Fatalf("EnsureRedirects did not create beads redirect: %v", err)
+	}
+
+	var buf bytes.Buffer
+	PrintRedirectConfirmations(&buf, wt)
+	got := buf.String()
+	if !strings.Contains(got, "Thrum redirect configured") {
+		t.Errorf("missing thrum line: %q", got)
+	}
+	if !strings.Contains(got, "Beads redirect configured") {
+		t.Errorf("missing beads line despite .beads/ present: %q", got)
+	}
+}

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -161,7 +161,7 @@ func (h *TmuxHandler) ensureSession(name string) (string, string, error) {
 	sanitized := ttmux.SanitizeSessionName(name)
 	target := sanitized + ":0.0"
 
-	if ttmux.HasSession(sanitized) {
+	if hasSessionFn(sanitized) {
 		return sanitized, target, nil
 	}
 
@@ -262,6 +262,15 @@ func (h *TmuxHandler) HandleCreate(ctx context.Context, params json.RawMessage) 
 
 	if err := ttmux.CreateSession(name, req.Cwd); err != nil {
 		return nil, err
+	}
+
+	// Tag the session so HandleStatus can discover it via tmux state
+	// alone (no identity file required). This is what surfaces
+	// --no-agent sessions in `thrum tmux status`: they have no
+	// identity file, but the tag is enough. Non-fatal — untagged
+	// sessions still work, they just fall back to identity-file scan.
+	if err := ttmux.SetUserOption(name, "@thrum-managed", "1"); err != nil {
+		slog.Warn("tmux set-option @thrum-managed failed", "session", name, "error", err)
 	}
 
 	// Track session→cwd mapping for auto-create and single-session enforcement
@@ -414,14 +423,45 @@ func (h *TmuxHandler) HandleKill(ctx context.Context, params json.RawMessage) (a
 	return nil, ttmux.KillSession(name)
 }
 
-// HandleSend sends text to a tmux session pane by routing through the queue
-// for unified safe dispatch.
+// HandleSend sends text to a tmux session pane. Agent-managed sessions
+// route through the queue for unified @system completion notification
+// and silence-detection sequencing. --no-agent sessions bypass the
+// queue and do a raw SendKeys — queue semantics rely on an agent being
+// registered (see queue_rpc.go:64-70) and do not apply when no agent
+// exists. This preserves manual/scripted keystroke injection into
+// daemon-managed bare sessions, which is what Step 10D.11 (check-pane)
+// and the `--no-agent` tmux-first workflow need.
 func (h *TmuxHandler) HandleSend(ctx context.Context, params json.RawMessage) (any, error) {
 	var req TmuxSendRequest
 	if err := json.Unmarshal(params, &req); err != nil {
 		return nil, fmt.Errorf("invalid request: %w", err)
 	}
-	// Route through queue for unified safe dispatch
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if req.Text == "" {
+		return nil, fmt.Errorf("text is required")
+	}
+
+	// Bypass the queue for sessions without a registered agent. The
+	// queue exists to wait for @system completion signals from an
+	// agent; on bare sessions no such agent exists and commands would
+	// otherwise pile up in "queued" forever (see queue_rpc.go:64-70).
+	agentName, _, _ := h.findIdentityForSession(ctx, req.Name)
+	if agentName == "" {
+		_, target, err := h.ensureSession(req.Name)
+		if err != nil {
+			return nil, err
+		}
+		if err := sendKeysFn(target, req.Text); err != nil {
+			return nil, fmt.Errorf("send-keys: %w", err)
+		}
+		// Return an empty QueueResponse so clients that ignore the
+		// body keep working and JSON-consumers see a consistent shape.
+		return &QueueResponse{}, nil
+	}
+
+	// Agent-managed session: preserve queue semantics.
 	queueParams, _ := json.Marshal(map[string]any{
 		"session":   req.Name,
 		"text":      req.Text,
@@ -508,6 +548,26 @@ func (h *TmuxHandler) HandleStatus(ctx context.Context, params json.RawMessage) 
 
 			sessions = append(sessions, info)
 		}
+	}
+
+	// Second pass: surface thrum-managed sessions that have no identity
+	// file (--no-agent) by reading tmux state directly. HandleCreate
+	// tags every session it creates with @thrum-managed=1, so we can
+	// safely filter out unrelated sessions on the same tmux socket.
+	names, _ := listSessionsFn()
+	for _, sessName := range names {
+		if seen[sessName] {
+			continue
+		}
+		val, err := getUserOptionFn(sessName, "@thrum-managed")
+		if err != nil || val != "1" {
+			continue
+		}
+		seen[sessName] = true
+		sessions = append(sessions, TmuxSessionInfo{
+			Name:  sessName,
+			State: "alive", // listed by tmux ⇒ present
+		})
 	}
 
 	return &TmuxStatusResponse{Sessions: sessions}, nil
@@ -1239,10 +1299,18 @@ var identityPollInterval = 500 * time.Millisecond
 // tmux-side-effect seams. Package vars so unit tests can exercise
 // runInlineQuickstart end-to-end without a real tmux daemon. Tests
 // must restore the original values via t.Cleanup.
+//
+// hasSessionFn / listSessionsFn / getUserOptionFn were added for
+// HandleSend's no-agent bypass path and HandleStatus's second pass
+// (thrum-ufv5.11/12) so both can be exercised end-to-end without
+// shelling out to tmux.
 var (
 	sendKeysFn       = ttmux.SendKeys
 	sendSpecialKeyFn = ttmux.SendSpecialKey
 	killSessionFn    = ttmux.KillSession
+	hasSessionFn     = ttmux.HasSession
+	listSessionsFn   = ttmux.ListSessions
+	getUserOptionFn  = ttmux.GetUserOption
 )
 
 // waitForIdentityFile blocks until the identity file at idPath appears

--- a/internal/daemon/rpc/tmux.go
+++ b/internal/daemon/rpc/tmux.go
@@ -265,12 +265,18 @@ func (h *TmuxHandler) HandleCreate(ctx context.Context, params json.RawMessage) 
 	}
 
 	// Tag the session so HandleStatus can discover it via tmux state
-	// alone (no identity file required). This is what surfaces
-	// --no-agent sessions in `thrum tmux status`: they have no
-	// identity file, but the tag is enough. Non-fatal — untagged
-	// sessions still work, they just fall back to identity-file scan.
-	if err := ttmux.SetUserOption(name, "@thrum-managed", "1"); err != nil {
-		slog.Warn("tmux set-option @thrum-managed failed", "session", name, "error", err)
+	// alone (no identity file required). For agent-managed sessions
+	// this is redundant with the identity file scan, but for
+	// --no-agent sessions the tag is the ONLY discovery path — if
+	// the tag fails to stick, the session becomes invisible to
+	// `thrum tmux status` for its lifetime. Roll back by killing the
+	// session and returning an error rather than silently orphaning
+	// it (thrum-ufv5.11 review #4).
+	if err := setUserOptionFn(name, "@thrum-managed", "1"); err != nil {
+		slog.Error("tmux set-option @thrum-managed failed; rolling back session create",
+			"session", name, "error", err)
+		_ = killSessionFn(name)
+		return nil, fmt.Errorf("tag session %q as thrum-managed: %w", name, err)
 	}
 
 	// Track session→cwd mapping for auto-create and single-session enforcement
@@ -556,6 +562,13 @@ func (h *TmuxHandler) HandleStatus(ctx context.Context, params json.RawMessage) 
 	// safely filter out unrelated sessions on the same tmux socket.
 	names, _ := listSessionsFn()
 	for _, sessName := range names {
+		// Defensive: tmux names beginning with "-" would be mis-parsed
+		// as flags by the subsequent show-option -t <name> call. Skip
+		// untrusted names (may come from sessions created outside
+		// thrum on a shared socket). thrum-ufv5.11 review #3.
+		if sessName == "" || strings.HasPrefix(sessName, "-") {
+			continue
+		}
 		if seen[sessName] {
 			continue
 		}
@@ -1300,9 +1313,10 @@ var identityPollInterval = 500 * time.Millisecond
 // runInlineQuickstart end-to-end without a real tmux daemon. Tests
 // must restore the original values via t.Cleanup.
 //
-// hasSessionFn / listSessionsFn / getUserOptionFn were added for
-// HandleSend's no-agent bypass path and HandleStatus's second pass
-// (thrum-ufv5.11/12) so both can be exercised end-to-end without
+// Seams hasSessionFn / listSessionsFn / getUserOptionFn /
+// setUserOptionFn were added for HandleSend's no-agent bypass path,
+// HandleStatus's second pass, and HandleCreate's tag-failure rollback
+// (thrum-ufv5.11/12) so all three can be exercised end-to-end without
 // shelling out to tmux.
 var (
 	sendKeysFn       = ttmux.SendKeys
@@ -1311,6 +1325,7 @@ var (
 	hasSessionFn     = ttmux.HasSession
 	listSessionsFn   = ttmux.ListSessions
 	getUserOptionFn  = ttmux.GetUserOption
+	setUserOptionFn  = ttmux.SetUserOption
 )
 
 // waitForIdentityFile blocks until the identity file at idPath appears

--- a/internal/daemon/rpc/tmux_no_agent_test.go
+++ b/internal/daemon/rpc/tmux_no_agent_test.go
@@ -1,0 +1,290 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/leonletto/thrum/internal/config"
+	"github.com/leonletto/thrum/internal/daemon/state"
+)
+
+// newNoAgentTestHandler builds a TmuxHandler wired to a temp .thrum
+// dir with an empty identities/ directory. Use this when the test
+// wants to exercise HandleSend or HandleStatus WITHOUT any identity
+// files present (the --no-agent session case).
+func newNoAgentTestHandler(t *testing.T) (*TmuxHandler, string) {
+	t.Helper()
+	t.Setenv("THRUM_HOME", "")
+	tmpDir := t.TempDir()
+	thrumDir := filepath.Join(tmpDir, ".thrum")
+	if err := os.MkdirAll(filepath.Join(thrumDir, "identities"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return NewTmuxHandler(thrumDir, nil), thrumDir
+}
+
+// stubTmuxSeams overrides the package-level seams used by HandleSend
+// and HandleStatus second-pass and restores them on cleanup.
+func stubTmuxSeams(t *testing.T,
+	has func(string) bool,
+	send func(string, string) error,
+	list func() ([]string, error),
+	getOpt func(string, string) (string, error),
+) {
+	t.Helper()
+	prevHas, prevSend, prevList, prevGet := hasSessionFn, sendKeysFn, listSessionsFn, getUserOptionFn
+	t.Cleanup(func() {
+		hasSessionFn = prevHas
+		sendKeysFn = prevSend
+		listSessionsFn = prevList
+		getUserOptionFn = prevGet
+	})
+	if has != nil {
+		hasSessionFn = has
+	}
+	if send != nil {
+		sendKeysFn = send
+	}
+	if list != nil {
+		listSessionsFn = list
+	}
+	if getOpt != nil {
+		getUserOptionFn = getOpt
+	}
+}
+
+// TestHandleSend_NoAgentBypassesQueue verifies that a tmux.send RPC
+// against a session with no registered agent does NOT hit the queue
+// path (which would reject with "queue requires an agent-managed
+// session"). Instead it must do a raw SendKeys and return a non-error
+// response. Regression guard for thrum-ufv5.12 (blocks Step 10D.11).
+func TestHandleSend_NoAgentBypassesQueue(t *testing.T) {
+	handler, _ := newNoAgentTestHandler(t)
+
+	var gotTarget, gotText string
+	var sendCalls int
+	stubTmuxSeams(t,
+		func(name string) bool { return true }, // session exists
+		func(target, text string) error {
+			sendCalls++
+			gotTarget = target
+			gotText = text
+			return nil
+		},
+		nil, nil,
+	)
+
+	params, _ := json.Marshal(TmuxSendRequest{Name: "foo-nopid", Text: "echo hi"})
+	resp, err := handler.HandleSend(context.Background(), params)
+	if err != nil {
+		t.Fatalf("HandleSend: %v", err)
+	}
+	if _, ok := resp.(*QueueResponse); !ok {
+		t.Fatalf("expected *QueueResponse response shape, got %T", resp)
+	}
+	if sendCalls != 1 {
+		t.Fatalf("sendKeysFn calls = %d, want 1", sendCalls)
+	}
+	if gotTarget != "foo-nopid:0.0" {
+		t.Errorf("target = %q, want %q", gotTarget, "foo-nopid:0.0")
+	}
+	if gotText != "echo hi" {
+		t.Errorf("text = %q, want %q", gotText, "echo hi")
+	}
+}
+
+// TestHandleSend_NoAgentPropagatesSendFailure ensures that a SendKeys
+// error on the no-agent bypass path surfaces to the caller instead of
+// being silently swallowed.
+func TestHandleSend_NoAgentPropagatesSendFailure(t *testing.T) {
+	handler, _ := newNoAgentTestHandler(t)
+
+	stubTmuxSeams(t,
+		func(string) bool { return true },
+		func(string, string) error { return errors.New("boom") },
+		nil, nil,
+	)
+
+	params, _ := json.Marshal(TmuxSendRequest{Name: "bare", Text: "echo"})
+	_, err := handler.HandleSend(context.Background(), params)
+	if err == nil || !containsAny(err.Error(), "send-keys", "boom") {
+		t.Fatalf("expected send-keys failure, got %v", err)
+	}
+}
+
+// TestHandleSend_AgentManagedStillRoutesThroughQueue proves the
+// agent-managed flow is untouched — if findIdentityForSession returns
+// a non-empty agent name, HandleSend must NOT call sendKeysFn directly
+// (that would skip queue/@system semantics). We assert this by stubbing
+// sendKeysFn to fail the test if called, then driving a request that
+// WILL fail inside HandleQueue (because no state is wired) — any
+// non-queue error or a sendKeysFn call would be a regression.
+func TestHandleSend_AgentManagedStillRoutesThroughQueue(t *testing.T) {
+	handler, thrumDir := newNoAgentTestHandler(t)
+
+	// Queue path requires a live state for position-counting; wire one
+	// so the call reaches tmux dispatch instead of panicking on nil.
+	st, err := state.NewState(thrumDir, thrumDir, "r_TESTNOAGENT", "")
+	if err != nil {
+		t.Fatalf("NewState: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	handler.state = st
+
+	// Seed an identity matching the session so findIdentityForSession
+	// returns non-empty.
+	idFile := &config.IdentityFile{
+		Agent:       config.AgentConfig{Name: "agent_a", Role: "implementer", Module: "x"},
+		TmuxSession: "managed-1:0.0",
+	}
+	if err := config.SaveIdentityFile(thrumDir, idFile); err != nil {
+		t.Fatalf("save identity: %v", err)
+	}
+
+	stubTmuxSeams(t,
+		func(string) bool { return true },
+		func(target, text string) error {
+			t.Fatalf("bypass SendKeys must not run for agent-managed session (target=%q)", target)
+			return nil
+		},
+		nil, nil,
+	)
+
+	params, _ := json.Marshal(TmuxSendRequest{Name: "managed-1", Text: "echo"})
+	// With state wired, the queue path will accept the command (the
+	// in-memory queue does not shell out to tmux on submission when
+	// the session is not silent). Success here — with no bypass
+	// SendKeys calls — proves routing is through the queue.
+	resp, callErr := handler.HandleSend(context.Background(), params)
+	if callErr != nil {
+		t.Fatalf("HandleSend (agent-managed): %v", callErr)
+	}
+	qr, ok := resp.(*QueueResponse)
+	if !ok || qr.CommandID == "" {
+		t.Fatalf("expected populated *QueueResponse, got %#v", resp)
+	}
+}
+
+// TestHandleStatus_IncludesNoAgentManagedSessions verifies the second
+// pass: sessions discovered via tmux's `@thrum-managed=1` tag appear
+// in the status response with empty Agent and State=alive. Regression
+// guard for thrum-ufv5.11 (Step 10C.1 / 10C.7).
+func TestHandleStatus_IncludesNoAgentManagedSessions(t *testing.T) {
+	handler, _ := newNoAgentTestHandler(t)
+
+	stubTmuxSeams(t,
+		func(string) bool { return true },
+		nil,
+		func() ([]string, error) { return []string{"bare-1", "unrelated", "bare-2"}, nil },
+		func(sess, key string) (string, error) {
+			if key != "@thrum-managed" {
+				return "", fmt.Errorf("unexpected key %q", key)
+			}
+			switch sess {
+			case "bare-1", "bare-2":
+				return "1", nil
+			default:
+				return "", errors.New("option not set")
+			}
+		},
+	)
+
+	resp, err := handler.HandleStatus(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("HandleStatus: %v", err)
+	}
+	list := resp.(*TmuxStatusResponse).Sessions
+	if len(list) != 2 {
+		t.Fatalf("got %d sessions, want 2: %+v", len(list), list)
+	}
+	byName := map[string]TmuxSessionInfo{}
+	for _, s := range list {
+		byName[s.Name] = s
+	}
+	for _, want := range []string{"bare-1", "bare-2"} {
+		info, ok := byName[want]
+		if !ok {
+			t.Fatalf("missing session %q", want)
+		}
+		if info.Agent != "" {
+			t.Errorf("%s: Agent = %q, want empty", want, info.Agent)
+		}
+		if info.State != "alive" {
+			t.Errorf("%s: State = %q, want alive", want, info.State)
+		}
+	}
+	if _, bad := byName["unrelated"]; bad {
+		t.Error("unrelated session must not leak into thrum tmux status")
+	}
+}
+
+// TestHandleStatus_DeduplicatesBetweenIdentityAndTagPasses ensures the
+// second pass does not double-list a session that also has an
+// identity file — the `seen` map spans both passes.
+func TestHandleStatus_DeduplicatesBetweenIdentityAndTagPasses(t *testing.T) {
+	handler, thrumDir := newNoAgentTestHandler(t)
+
+	idFile := &config.IdentityFile{
+		Version:     4,
+		Agent:       config.AgentConfig{Name: "agent_a", Role: "implementer", Module: "x"},
+		TmuxSession: "shared:0.0",
+	}
+	if err := config.SaveIdentityFile(thrumDir, idFile); err != nil {
+		t.Fatalf("save identity: %v", err)
+	}
+
+	stubTmuxSeams(t,
+		func(string) bool { return true },
+		nil,
+		func() ([]string, error) { return []string{"shared"}, nil },
+		func(_, _ string) (string, error) { return "1", nil },
+	)
+
+	resp, err := handler.HandleStatus(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("HandleStatus: %v", err)
+	}
+	list := resp.(*TmuxStatusResponse).Sessions
+	if len(list) != 1 {
+		t.Fatalf("expected 1 deduplicated session, got %d: %+v", len(list), list)
+	}
+	if list[0].Agent != "agent_a" {
+		t.Errorf("Agent = %q, want agent_a (identity pass must win)", list[0].Agent)
+	}
+}
+
+// TestHandleSend_RejectsEmptyFields ensures HandleSend validates
+// required fields before attempting any routing decision.
+func TestHandleSend_RejectsEmptyFields(t *testing.T) {
+	handler, _ := newNoAgentTestHandler(t)
+	cases := []struct {
+		req  TmuxSendRequest
+		want string
+	}{
+		{TmuxSendRequest{Name: "", Text: "x"}, "name is required"},
+		{TmuxSendRequest{Name: "s", Text: ""}, "text is required"},
+	}
+	for _, tc := range cases {
+		params, _ := json.Marshal(tc.req)
+		_, err := handler.HandleSend(context.Background(), params)
+		if err == nil || err.Error() != tc.want {
+			t.Errorf("req=%+v err=%v want=%q", tc.req, err, tc.want)
+		}
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/daemon/rpc/tmux_no_agent_test.go
+++ b/internal/daemon/rpc/tmux_no_agent_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/leonletto/thrum/internal/config"
@@ -112,7 +113,7 @@ func TestHandleSend_NoAgentPropagatesSendFailure(t *testing.T) {
 
 	params, _ := json.Marshal(TmuxSendRequest{Name: "bare", Text: "echo"})
 	_, err := handler.HandleSend(context.Background(), params)
-	if err == nil || !containsAny(err.Error(), "send-keys", "boom") {
+	if err == nil || (!strings.Contains(err.Error(), "send-keys") && !strings.Contains(err.Error(), "boom")) {
 		t.Fatalf("expected send-keys failure, got %v", err)
 	}
 }
@@ -258,6 +259,57 @@ func TestHandleStatus_DeduplicatesBetweenIdentityAndTagPasses(t *testing.T) {
 	}
 }
 
+// TestHandleCreate_TagFailureRollsBackSession verifies the rollback
+// invariant from thrum-ufv5.11 review #4: if SetUserOption fails to
+// tag a newly-created session, HandleCreate must kill the session and
+// return an error. Leaving an untagged session alive would break the
+// "--no-agent sessions appear in status" contract for its lifetime
+// (no identity-file fallback exists for bare sessions).
+func TestHandleCreate_TagFailureRollsBackSession(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/tmux"); err != nil {
+		if _, err := os.Stat("/opt/homebrew/bin/tmux"); err != nil {
+			t.Skip("tmux binary not available on this host")
+		}
+	}
+
+	handler, _ := newNoAgentTestHandler(t)
+	cwd := t.TempDir()
+
+	prevSet, prevKill := setUserOptionFn, killSessionFn
+	t.Cleanup(func() {
+		setUserOptionFn = prevSet
+		killSessionFn = prevKill
+	})
+
+	setUserOptionFn = func(string, string, string) error {
+		return errors.New("simulated set-option failure")
+	}
+	var killCalls []string
+	killSessionFn = func(name string) error {
+		killCalls = append(killCalls, name)
+		// Still destroy the real tmux session so the test doesn't leak.
+		return prevKill(name)
+	}
+
+	params, _ := json.Marshal(map[string]any{
+		"name":     "rollback-probe",
+		"cwd":      cwd,
+		"no_agent": true,
+	})
+	_, err := handler.HandleCreate(context.Background(), json.RawMessage(params))
+	if err == nil {
+		// Clean up the dangling session before failing.
+		_ = prevKill("rollback-probe")
+		t.Fatal("expected error when set-option fails; got nil")
+	}
+	if !strings.Contains(err.Error(), "tag session") {
+		t.Errorf("error = %v, want contains 'tag session'", err)
+	}
+	if len(killCalls) != 1 || killCalls[0] != "rollback-probe" {
+		t.Errorf("killSessionFn calls = %v, want [rollback-probe]", killCalls)
+	}
+}
+
 // TestHandleSend_RejectsEmptyFields ensures HandleSend validates
 // required fields before attempting any routing decision.
 func TestHandleSend_RejectsEmptyFields(t *testing.T) {
@@ -278,13 +330,3 @@ func TestHandleSend_RejectsEmptyFields(t *testing.T) {
 	}
 }
 
-func containsAny(s string, subs ...string) bool {
-	for _, sub := range subs {
-		for i := 0; i+len(sub) <= len(s); i++ {
-			if s[i:i+len(sub)] == sub {
-				return true
-			}
-		}
-	}
-	return false
-}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -169,3 +169,47 @@ func IsSilent(session string) bool {
 func InTmux() bool {
 	return os.Getenv("TMUX") != ""
 }
+
+// SetUserOption sets a tmux user-option (a name starting with "@") on a
+// session. User-options are persisted in tmux's own state for the life
+// of the session and can be read back with GetUserOption. Thrum uses
+// this to tag sessions it created so they can be discovered from tmux
+// state alone — no identity file required (needed for --no-agent
+// sessions which have no registered agent).
+func SetUserOption(session, key, value string) error {
+	return safecmd.TmuxRun(context.Background(), "set-option", "-t", session, key, value)
+}
+
+// GetUserOption reads a tmux user-option from a session. Returns the
+// raw value on success, and (string, error) on failure — callers
+// typically treat any error as "unset" / "not tagged". Trailing
+// whitespace is trimmed.
+func GetUserOption(session, key string) (string, error) {
+	out, err := safecmd.Tmux(context.Background(), "show-option", "-v", "-t", session, key)
+	if err != nil {
+		return "", fmt.Errorf("tmux show-option %s: %w", key, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ListSessions returns the names of all tmux sessions visible on the
+// current tmux socket. Empty list is a valid result (no sessions).
+// Missing tmux server (exit 1 with "no server running") is returned as
+// an empty list, not an error — callers can treat "nothing to list"
+// uniformly.
+func ListSessions() ([]string, error) {
+	out, err := safecmd.Tmux(context.Background(), "list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		// tmux returns non-zero when no server is running. Map that to
+		// an empty list so callers don't need to string-match errors.
+		if strings.Contains(err.Error(), "no server running") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("tmux list-sessions: %w", err)
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+	return strings.Split(raw, "\n"), nil
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -184,8 +184,13 @@ func SetUserOption(session, key, value string) error {
 // raw value on success, and (string, error) on failure — callers
 // typically treat any error as "unset" / "not tagged". Trailing
 // whitespace is trimmed.
+//
+// -q suppresses "unknown option" errors on tmux versions that treat
+// that as an error; combined with the explicit session scope from -t,
+// this prevents a server/global user-option with the same name from
+// leaking into the per-session filter result (thrum-ufv5.11 review #2).
 func GetUserOption(session, key string) (string, error) {
-	out, err := safecmd.Tmux(context.Background(), "show-option", "-v", "-t", session, key)
+	out, err := safecmd.Tmux(context.Background(), "show-option", "-q", "-v", "-t", session, key)
 	if err != nil {
 		return "", fmt.Errorf("tmux show-option %s: %w", key, err)
 	}
@@ -194,15 +199,14 @@ func GetUserOption(session, key string) (string, error) {
 
 // ListSessions returns the names of all tmux sessions visible on the
 // current tmux socket. Empty list is a valid result (no sessions).
-// Missing tmux server (exit 1 with "no server running") is returned as
-// an empty list, not an error — callers can treat "nothing to list"
-// uniformly.
+// Missing tmux server (exit 1 with "no server running") and tmux 3.3+
+// "no sessions" on a live server are both mapped to an empty list so
+// callers don't need to string-match errors (thrum-ufv5.11 review #1).
 func ListSessions() ([]string, error) {
 	out, err := safecmd.Tmux(context.Background(), "list-sessions", "-F", "#{session_name}")
 	if err != nil {
-		// tmux returns non-zero when no server is running. Map that to
-		// an empty list so callers don't need to string-match errors.
-		if strings.Contains(err.Error(), "no server running") {
+		msg := err.Error()
+		if strings.Contains(msg, "no server running") || strings.Contains(msg, "no sessions") {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("tmux list-sessions: %w", err)


### PR DESCRIPTION
Resolves **thrum-ufv5.11**, **thrum-ufv5.12**, **thrum-ufv5.13** from the v0.9.0 release-test sweep.

## Summary

- `thrum tmux send` now bypasses the queue for `--no-agent` sessions and does raw keystroke injection via `ttmux.SendKeys`. Agent-managed sessions still route through the queue so `@system` completion delivery and silence semantics are preserved.
- `thrum tmux status` does a second pass over tmux sessions tagged with `@thrum-managed=1` and includes `--no-agent` sessions with an empty Agent column.
- `thrum worktree create` now prints `✓ Beads redirect configured` when the beads redirect file is actually written, symmetrically to the existing `✓ Thrum redirect configured` line.

## Commits

1. `f35bdbab` fix(tmux): allow raw send on no-agent sessions and show them in status
2. `63451102` fix(worktree): print beads redirect confirmation
3. `fbe34b5b` fix: address dual-review findings on thrum-ufv5.11/12/13

## Dual-review

**Plan-verify:** MEETS_SPEC across all 13 requirements.
**Code-review:** 1 BLOCKING + 3 IMPORTANT + 3 MINOR surfaced; all addressed in commit `fbe34b5b` (#5-#6 landed in-batch; #7 filed as follow-up **thrum-h01v**: audit `EnsureWorktreeRedirects` call sites outside `worktree create` for consistency).

## Test plan

- [x] `make test` on touched packages (`internal/tmux`, `internal/cli`, `internal/daemon/rpc`) green.
- [x] Regression test `TestHandleSend_AgentManagedStillRoutesThroughQueue` pins the queue-path invariant for agent sessions.
- [x] Regression test `TestHandleCreate_TagFailureRollsBackSession` pins the rollback invariant when `@thrum-managed` tagging fails.
- [x] 6 new subtests cover HandleSend bypass/error/agent-path + HandleStatus second-pass/dedupe/empty-field; 2 new subtests cover `PrintRedirectConfirmations` thrum-only and beads-present cases.