### PR TITLE
fix(ci): resolve 6 Linux-only test failures blocking v0.9.0

### DIFF
--- a/cmd/thrum/main.go
+++ b/cmd/thrum/main.go
@@ -4656,6 +4656,18 @@ Examples:
   thrum overview
   thrum overview --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Always emit the legacy 'Tip:' trailer in text mode, even when
+			// the daemon connect or RPC fails. The L5 contract is that
+			// commands wired to cli.LegacyHint produce a tip on stderr-or-
+			// stdout regardless of the action outcome — useful guidance
+			// (e.g. "next, try X") still helps the user when the daemon is
+			// down. JSON / quiet modes keep the structured-output contract.
+			defer func() {
+				if !flagJSON && !flagQuiet {
+					fmt.Print(cli.LegacyHint("overview", flagQuiet, flagJSON))
+				}
+			}()
+
 			client, err := getClient()
 			if err != nil {
 				return fmt.Errorf("failed to connect to daemon: %w", err)
@@ -4678,9 +4690,6 @@ Examples:
 				return cli.EmitJSON(result)
 			}
 			fmt.Print(cli.FormatOverview(result))
-			if !flagQuiet {
-				fmt.Print(cli.LegacyHint("overview", flagQuiet, flagJSON))
-			}
 			return nil
 		},
 	}
@@ -8149,21 +8158,20 @@ func tmuxCmd() *cobra.Command {
 			noAgent, _ := cmd.Flags().GetBool("no-agent")
 			force, _ := cmd.Flags().GetBool("force")
 
-			client, err := getClient()
-			if err != nil {
-				return fmt.Errorf("connect to daemon: %w", err)
-			}
-			defer func() { _ = client.Close() }()
-
-			// Hint pipeline: pre-action collection + gating.
-			state := cli.NewLiveStateAccessor(client)
+			// Hint pipeline: pre-action collection + gating runs BEFORE the
+			// daemon connect. The pre-action hints (not-a-worktree,
+			// session-exists, identity-exists) are FS-only by design — they
+			// must fire even when the daemon is unreachable so users get
+			// actionable guidance instead of a cryptic socket error. Use
+			// FSOnlyStateAccessor here; the LiveStateAccessor below is for
+			// post-action observations that legitimately need the RPC.
 			hintFlags := map[string]any{"cwd": cwd, "force": force}
 			preCtx := cli.HintCtx{
 				Command: "tmux.create",
 				Args:    args,
 				Flags:   hintFlags,
 				Post:    false,
-				State:   state,
+				State:   cli.NewFSOnlyStateAccessor(),
 			}
 			preHints := cli.Collect(preCtx)
 			if abortErr := cli.HandlePreAction(preHints, force); abortErr != nil {
@@ -8189,6 +8197,20 @@ func tmuxCmd() *cobra.Command {
 				}
 				return cli.EmitAbort(abortErr, flagQuiet, flagJSON)
 			}
+
+			// Pre-action checks passed; now connect to the daemon for the
+			// actual mutation. Failure here is a real error (we already know
+			// the request is otherwise sensible).
+			client, err := getClient()
+			if err != nil {
+				return fmt.Errorf("connect to daemon: %w", err)
+			}
+			defer func() { _ = client.Close() }()
+
+			// LiveStateAccessor is needed for post-action hint collection
+			// (session-exists liveness, identity-status liveness) which
+			// legitimately needs the daemon view.
+			state := cli.NewLiveStateAccessor(client)
 
 			// Snapshot pre-state for the identity-replaced audit marker. Done
 			// BEFORE the mutation so we can detect whether --force overwrote

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -348,8 +348,12 @@ func TestInit_WritesIdentityBlock(t *testing.T) {
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 
-	// git init
-	cmd := exec.Command("git", "init")
+	// git init -b main: force the default branch name so the test is
+	// deterministic on systems without init.defaultBranch=main set globally
+	// (e.g. fresh GH Actions Ubuntu runners). Without -b, modern git defaults
+	// to "master" on those runners and TestInit_Integration_FreshCloneAttachesToRemoteASync
+	// fails when it later runs `git push bareremote main`.
+	cmd := exec.Command("git", "init", "-b", "main")
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to init git repo: %v", err)

--- a/internal/identity/guard/daemon_resolve.go
+++ b/internal/identity/guard/daemon_resolve.go
@@ -189,6 +189,13 @@ func DaemonResolve(ctx context.Context, cfg Config, req DaemonResolveRequest, lo
 	return ResolvedCaller{AgentID: req.CallerAgentID}, nil
 }
 
+// closestRuntimeAncestorFn is the runtime-ancestor probe used by
+// resolveByChain. Exposed as a var so tests in this package can substitute
+// a deterministic stub on platforms where the test process has no real
+// AI-runtime ancestor in its chain (e.g. fresh GH Actions runners).
+// Production code MUST NOT mutate this.
+var closestRuntimeAncestorFn = ClosestRuntimeAncestor
+
 // resolveByChain walks ConnectingPID's ancestor chain and returns the
 // agent_id of the first registered identity whose AgentPID appears in
 // the chain AND is still alive. Returns "" when the walk is disabled
@@ -213,7 +220,7 @@ func resolveByChain(ctx context.Context, req DaemonResolveRequest) string {
 	// when the caller has a recognized runtime in its ancestor chain.
 	// Non-runtime callers (bare shell / cron / script) fall through
 	// to the anonymous-allow or anonymous-deny path per policy.
-	if rtPID, _, _ := ClosestRuntimeAncestor(ctx, req.ConnectingPID); rtPID == 0 {
+	if rtPID, _, _ := closestRuntimeAncestorFn(ctx, req.ConnectingPID); rtPID == 0 {
 		return ""
 	}
 	chain, err := WalkAncestors(ctx, req.ConnectingPID)

--- a/internal/identity/guard/daemon_resolve_chain_test.go
+++ b/internal/identity/guard/daemon_resolve_chain_test.go
@@ -23,6 +23,21 @@ func seedIdentityFile(t *testing.T, dir, name string, agentPID int) {
 	}
 }
 
+// stubRuntimeAncestorPresent forces the chain-walk's runtime-ancestor
+// precondition to succeed for the duration of the test. Without this,
+// tests whose process tree lacks an AI runtime ancestor (e.g. bare GH
+// Actions runners) hit the §Rule #4‴ step 2 fallthrough and return
+// "" before the chain walk runs. The PID value is arbitrary — only
+// non-zero matters.
+func stubRuntimeAncestorPresent(t *testing.T) {
+	t.Helper()
+	prev := closestRuntimeAncestorFn
+	closestRuntimeAncestorFn = func(_ context.Context, _ int) (int, string, error) {
+		return 1, "claude", nil
+	}
+	t.Cleanup(func() { closestRuntimeAncestorFn = prev })
+}
+
 // TestDaemonResolve_ChainWalk_FindsOwner proves that on the anonymous-
 // peercred branch, if the connecting process's ancestor chain contains
 // a registered agent's AgentPID AND that PID is alive, DaemonResolve
@@ -30,6 +45,7 @@ func seedIdentityFile(t *testing.T, dir, name string, agentPID int) {
 // closed. This is Rule #4‴ ancestor-chain authentication — the
 // daemon-side complement to CWD-based peercred matching.
 func TestDaemonResolve_ChainWalk_FindsOwner(t *testing.T) {
+	stubRuntimeAncestorPresent(t)
 	identitiesDir := t.TempDir()
 	self := os.Getpid() // definitely alive, in its own chain
 	seedIdentityFile(t, identitiesDir, "impl_self", self)
@@ -77,6 +93,7 @@ func TestDaemonResolve_ChainWalk_DeadPIDFallsClosed(t *testing.T) {
 // we reject with identity_mismatch — forgery defense applies to the
 // chain-authenticated path too, not just peercred.
 func TestDaemonResolve_ChainWalk_MismatchClaimRejected(t *testing.T) {
+	stubRuntimeAncestorPresent(t)
 	identitiesDir := t.TempDir()
 	self := os.Getpid()
 	seedIdentityFile(t, identitiesDir, "impl_self", self)


### PR DESCRIPTION
## Summary

Three independent CI-environment artifacts. All tests pass locally on macOS but fail on bare GH Actions Ubuntu runners.

- **A. guard chain-walk (2 tests)** — `resolveByChain` enforces a runtime-ancestor precondition; CI runners have no claude/codex in the chain. Fix: hoist `ClosestRuntimeAncestor` behind a package-level var (`closestRuntimeAncestorFn`) and add a `stubRuntimeAncestorPresent(t)` helper. Production code untouched.
- **B. cmd/thrum hints (3 tests)** — `tmux create` and `overview` had daemon-connect ahead of hint emission. Fix:
  - `tmux create`: collect pre-action hints with `FSOnlyStateAccessor` BEFORE `getClient`. Daemon connect only happens after the pre-action gate clears.
  - `overview`: emit `cli.LegacyHint("overview")` via `defer` so the L5 'Tip:' trailer fires regardless of connect outcome.
- **C. init fresh-clone (1 test)** — `initGitRepo` used bare `git init`, which on Ubuntu CI defaults to `master`; a later `git push bareremote main` fails. Fix: `git init -b main`.

Closes thrum-7fco.

## Test plan

- [x] `golangci-lint run --timeout=3m` → 0 issues
- [x] `go build ./...` → clean
- [x] `go test ./... -race -count=1` → all pass locally
- [ ] CI run on this PR (Linux) — the actual environment that was failing