### PR TITLE
fix(peercred): distinguish unknown-state from provably-anonymous (thrum-ndtw)

### DIFF
--- a/internal/daemon/identity/peercred/export_unix_test.go
+++ b/internal/daemon/identity/peercred/export_unix_test.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package peercred
+
+// SetProcessCWDFnForTest replaces the processCWD function used by Resolve
+// with fn, returning a restore closure. Tests use this to force gopsutil
+// failures and verify the resolver's error-classification contract
+// (see thrum-ndtw).
+func SetProcessCWDFnForTest(fn func(int) (string, error)) func() {
+	prev := processCWDFn
+	processCWDFn = fn
+	return func() { processCWDFn = prev }
+}

--- a/internal/daemon/identity/peercred/resolver_unix.go
+++ b/internal/daemon/identity/peercred/resolver_unix.go
@@ -3,6 +3,7 @@
 package peercred
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -32,26 +33,48 @@ func NewResolver(lister AgentLister) Resolver {
 	return &unixResolver{lister: lister}
 }
 
+// processCWDFn is the function used to look up a process's CWD by PID.
+// Indirected through a package-level variable so tests can inject forced
+// failures — see SetProcessCWDFnForTest in export_unix_test.go.
+var processCWDFn = processCWD
+
 // Resolve extracts the connecting process PID via kernel peer credentials,
 // resolves its CWD, walks upward to find the git root, and matches against
 // registered agent worktrees.
+//
+// Error taxonomy (see thrum-ndtw): the caller (server.go) distinguishes
+// "provably anonymous" (ErrAnonymous → anonymous allowlist enforced) from
+// "unknown state" (any other error → fall through to legacy client-asserted
+// identity, pre-v0.9.0 behavior). Only steps 3 and 5 — empty git root and
+// matchWorktree no-match — produce ErrAnonymous, because only those states
+// are provable evidence that the caller is outside every registered
+// worktree. Introspection failures at steps 1 and 2 cannot prove that and
+// therefore return raw errors so server.go takes the legacy path.
 func (r *unixResolver) Resolve(conn net.Conn) (*ResolvedIdentity, error) {
 	// Step 1: Extract PID via kernel peer credentials.
+	// UNKNOWN state on failure (see Error taxonomy above) — return raw errors.
 	creds, err := tspeer.Get(conn)
 	if err != nil {
+		slog.Warn("peercred.resolve step=pid failed", "err", err.Error())
 		return nil, fmt.Errorf("peercred: get peer credentials: %w", err)
 	}
 	pid, ok := creds.PID()
 	if !ok || pid == 0 {
-		return nil, fmt.Errorf("%w: no PID in peer credentials", ErrAnonymous)
+		slog.Warn("peercred.resolve step=pid failed", "err", "no PID in peer credentials")
+		return nil, errors.New("peercred: no PID in peer credentials")
 	}
 	slog.Debug("peercred.resolve step=pid", "pid", pid)
 
 	// Step 2: Resolve PID → CWD.
-	cwd, err := processCWD(pid)
+	// UNKNOWN state on failure — gopsutil can miss for any of: process exited
+	// in the race window, permission model drift on macOS, short-lived shell
+	// subprocess, etc. We cannot prove the caller is anonymous, so return a
+	// raw error (NOT wrapped with ErrAnonymous) to route through server.go's
+	// legacy fallthrough.
+	cwd, err := processCWDFn(pid)
 	if err != nil {
-		// Process may have exited in the race window between connect and here.
-		return nil, fmt.Errorf("%w: cannot read CWD for PID %d: %v", ErrAnonymous, pid, err)
+		slog.Warn("peercred.resolve step=cwd failed", "pid", pid, "err", err.Error())
+		return nil, fmt.Errorf("peercred: cannot read CWD for PID %d: %w", pid, err)
 	}
 	slog.Debug("peercred.resolve step=cwd", "pid", pid, "cwd", cwd)
 

--- a/internal/daemon/identity/peercred/resolver_unix_ndtw_test.go
+++ b/internal/daemon/identity/peercred/resolver_unix_ndtw_test.go
@@ -1,0 +1,69 @@
+//go:build unix
+
+package peercred_test
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/leonletto/thrum/internal/daemon/identity/peercred"
+)
+
+// TestResolve_CWDFails_NotAnon verifies that when gopsutil cannot inspect
+// the connecting process (permission denied, race against process exit,
+// macOS-specific failure modes), the resolver returns a non-ErrAnonymous
+// error. Wrapping introspection failure with ErrAnonymous would wrongly
+// flip server.go from the "unknown-state → legacy fallthrough" branch
+// into the "provably anonymous → allowlist rejection" branch — the exact
+// bug thrum-ndtw fixes: interactive shells in a registered worktree got
+// their mutating RPCs rejected because gopsutil.Cwd failed on their
+// interactive zsh PID.
+//
+// Test name kept short to stay under the 104-char macOS unix-socket path
+// limit that t.TempDir + the test name can blow past.
+func TestResolve_CWDFails_NotAnon(t *testing.T) {
+	forcedErr := errors.New("gopsutil: forced failure for test")
+	restore := peercred.SetProcessCWDFnForTest(func(_ int) (string, error) {
+		return "", forcedErr
+	})
+	defer restore()
+
+	resolver := peercred.NewResolver(&staticLister{agents: nil})
+
+	srv, _, cleanup := makeUnixPair(t)
+	defer cleanup()
+
+	_, err := resolver.Resolve(srv)
+	if err == nil {
+		t.Fatal("expected non-nil error when processCWD fails, got nil")
+	}
+	if errors.Is(err, peercred.ErrAnonymous) {
+		t.Errorf("processCWD failure must NOT wrap ErrAnonymous (would trigger anonymous-allowlist rejection); got: %v", err)
+	}
+	if !errors.Is(err, forcedErr) {
+		t.Errorf("original gopsutil error should remain retrievable via errors.Is; got: %v", err)
+	}
+}
+
+// TestResolve_PIDFails_NotAnon verifies the same contract for step 1:
+// when tailscale/peercred cannot extract peer credentials (e.g. non-unix
+// conn like net.Pipe, kernel-level denial), the resolver must return a
+// non-ErrAnonymous error. Regression guard — current code already does
+// this at the tspeer.Get call site, but the matching PID=0 branch
+// historically wrapped with ErrAnonymous and must stay unwrapped after
+// thrum-ndtw.
+func TestResolve_PIDFails_NotAnon(t *testing.T) {
+	resolver := peercred.NewResolver(&staticLister{agents: nil})
+
+	c1, _ := net.Pipe()
+	defer c1.Close()
+
+	_, err := resolver.Resolve(c1)
+	if err == nil {
+		t.Fatal("expected non-nil error when tspeer.Get fails on net.Pipe")
+	}
+	if errors.Is(err, peercred.ErrAnonymous) {
+		t.Errorf("tspeer.Get failure must NOT wrap ErrAnonymous; got: %v", err)
+	}
+}

--- a/internal/daemon/server_peercred_ndtw_test.go
+++ b/internal/daemon/server_peercred_ndtw_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/leonletto/thrum/internal/daemon/identity/peercred"
+)
+
+// introspectionFailResolver reproduces the post-thrum-ndtw contract: when
+// the resolver cannot introspect the connecting process (gopsutil.Cwd
+// fails, tspeer.Get fails, …), it returns a plain error — NOT wrapped
+// with ErrAnonymous. server.go must then leave ctxWithIdentity un-injected
+// so the request takes the legacy client-asserted identity path instead of
+// being rejected as anonymous.
+type introspectionFailResolver struct{}
+
+func (i *introspectionFailResolver) Resolve(_ net.Conn) (*peercred.ResolvedIdentity, error) {
+	return nil, errors.New("peercred: cannot read CWD for PID 999: permission denied")
+}
+
+// TestHandleConnection_ResolverIntrospectFail_LegacyFallthrough verifies that
+// a non-ErrAnonymous resolver error routes the request through legacy
+// client-asserted identity handling (pre-v0.9.0 behavior), letting a
+// non-allowlisted mutating RPC succeed.
+//
+// Regression guard for thrum-ndtw: an interactive shell where gopsutil.Cwd
+// fails on its PID must NOT be rejected as anonymous — it must fall through
+// to legacy instead. Paired with peercred.TestResolve_CWDFails_NotAnon which
+// enforces the resolver-side half of the contract.
+func TestHandleConnection_ResolverIntrospectFail_LegacyFallthrough(t *testing.T) {
+	// Short tmp prefix to stay under macOS 104-char unix socket path limit.
+	tmpDir, err := os.MkdirTemp("", "ndtw")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	socketPath := filepath.Join(tmpDir, "t.sock")
+
+	server := NewServer(socketPath)
+	server.SetIdentityResolver(&introspectionFailResolver{})
+
+	// Non-allowlisted method. The anonymous allowlist would reject this if
+	// the resolver's error were classified as "provably anonymous"; under
+	// the legacy fallthrough the handler runs and returns success.
+	server.RegisterHandler("test.mutating", func(_ context.Context, _ json.RawMessage) (any, error) {
+		return map[string]any{"ok": true}, nil
+	})
+
+	if err := server.Start(t.Context()); err != nil {
+		t.Fatalf("server start: %v", err)
+	}
+	defer func() { _ = server.Stop() }()
+
+	waitForSocketReady(t, socketPath)
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	raw := sendRPC(t, conn, "test.mutating", 1)
+	_, rpcErr := parseRPCResponse(t, raw)
+	if rpcErr != nil {
+		t.Fatalf("non-allowlisted method should succeed via legacy fallthrough, got error %d: %s", rpcErr.Code, rpcErr.Message)
+	}
+}


### PR DESCRIPTION
## Summary

- peercred resolver steps 1+2 (tspeer.Get / gopsutil.Cwd) wrongly wrapped their
  errors with `ErrAnonymous`, flipping `server.go` into the "provably anonymous
  → allowlist rejection" branch on *introspection failures*. But a kernel or
  gopsutil miss doesn't PROVE the caller is anonymous — we just don't know.
  Drop the wrap; return raw errors; let `server.go` fall through to legacy
  client-asserted identity (pre-v0.9.0 behavior).
- Keep the `ErrAnonymous` wrap at step 3 (`findGitRoot` empty) and step 5
  (`matchWorktree` no-match) — those states ARE provable evidence of an
  anonymous caller.
- Add `slog.Warn` at both introspection-failure paths so future diagnostics
  don't need another instrumentation round-trip.

## Error taxonomy

| Case                              | Reality           | Behavior after fix                      |
| --------------------------------- | ----------------- | --------------------------------------- |
| `tspeer.Get` / PID=0 fails        | UNKNOWN           | Raw error → legacy client-asserted      |
| `gopsutil.Cwd` fails              | UNKNOWN           | Raw error → legacy client-asserted      |
| `findGitRoot` returns empty       | Provably anonymous | `ErrAnonymous` → allowlist rejection   |
| `matchWorktree` no-match          | Provably anonymous | `ErrAnonymous` → allowlist rejection   |

## Security

Net-zero regression. Pre-v0.9.0 already accepted client-asserted identity on
local unix socket connections; this fix only restores that behavior on the
narrow "we can't inspect the process" path. Attackers outside a registered
worktree still resolve CWD → no-match → `ErrAnonymous` → rejected.

## Test plan

- [x] `peercred.TestResolve_CWDFails_NotAnon` — gopsutil failure must not wrap
  `ErrAnonymous` (uses new `processCWDFn` test seam).
- [x] `peercred.TestResolve_PIDFails_NotAnon` — tspeer.Get failure regression
  guard.
- [x] `daemon.TestHandleConnection_ResolverIntrospectFail_LegacyFallthrough` —
  end-to-end: non-`ErrAnonymous` resolver error → mutating RPC succeeds via
  legacy fallthrough.
- [x] Existing `TestResolve_NoMatch` / `TestResolve_CWDOutsideWorktree` still
  return `ErrAnonymous` for provably-anonymous cases.
- [x] `make test` PASS with `-race`.
- [x] `make lint` clean (0 issues).
- [ ] Leon verifies `thrum agent delete` from the failing interactive zsh in
  `/Users/leon/dev/Personal/semantec_retrieval_engine` now succeeds.

## Issue

Closes thrum-ndtw.